### PR TITLE
Add variables to GFS_init_type

### DIFF
--- a/GFS_layer/GFS_driver.F90
+++ b/GFS_layer/GFS_driver.F90
@@ -152,7 +152,8 @@ module GFS_driver
                      Init_parm%iau_offset,                         &
                      Init_parm%tracer_names,                       &
                      Init_parm%input_nml_file, Init_parm%tile_num, &
-                     Init_parm%blksz)
+                     Init_parm%blksz, Init_parm%hydro,             &
+                     Init_parm%do_inline_mp, Init_parm%do_cosp)
 
 
     call read_o3data  (Model%ntoz, Model%me, Model%master)
@@ -218,7 +219,7 @@ module GFS_driver
 
     !--- initialize GFDL Cloud microphysics
     if (Model%ncld == 5) then
-      call gfdl_cld_mp_init (Model%input_nml_file, Init_parm%logunit, Model%dycore_hydrostatic)
+      call gfdl_cld_mp_init (Model%input_nml_file, Init_parm%logunit, Init_parm%hydro)
     endif
 
     !--- initialize ras

--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -85,6 +85,10 @@ module GFS_typedefs
     character(len=65) :: fn_nml                   !< namelist filename
     character(len=:), pointer, dimension(:) :: input_nml_file => null() !< character string containing full namelist
                                                                         !< for use with internal file reads
+    logical :: hydro                             !< whether the dynamical core is hydrostatic
+    logical :: do_inline_mp                      !< flag for GFDL cloud microphysics
+    logical :: do_cosp                           !< flag for COSP
+
   end type GFS_init_type
 
 
@@ -1999,7 +2003,8 @@ module GFS_typedefs
                                  cnx, cny, gnx, gny, dt_dycore,     &
                                  dt_phys, idat, jdat, iau_offset,   &
                                  tracer_names, input_nml_file,      &
-                                 tile_num, blksz)
+                                 tile_num, blksz, hydro,            &
+                                 do_inline_mp, do_cosp)
 
     !--- modules
     use physcons,         only: max_lon, max_lat, min_lon, min_lat, &
@@ -2036,6 +2041,9 @@ module GFS_typedefs
     character(len=32),      intent(in) :: tracer_names(:)
     character(len=:),       intent(in),  dimension(:), pointer :: input_nml_file
     integer,                intent(in) :: blksz(:)
+    logical,                intent(in) :: hydro
+    logical,                intent(in) :: do_inline_mp
+    logical,                intent(in) :: do_cosp
     !--- local variables
     integer :: n, i, j
     integer :: ios
@@ -2108,15 +2116,8 @@ module GFS_typedefs
     logical              :: fixed_sollat   = .false.         !< flag to fix solar latitude
     logical              :: daily_mean     = .false.         !< flag to replace cosz with daily mean value
 
-    !--- dynamical core parameters
-    logical              :: dycore_hydrostatic  = .true.     !< whether the dynamical core is hydrostatic
-
     !--- GFDL microphysical parameters
     logical              :: do_sat_adj   = .false.           !< flag for fast saturation adjustment
-    logical              :: do_inline_mp = .false.           !< flag for GFDL cloud microphysics
-
-    !--- The CFMIP Observation Simulator Package (COSP)
-    logical              :: do_cosp = .false.                !< flag for COSP
 
     !--- Z-C microphysical parameters
     integer              :: ncld           =  1                 !< cnoice of cloud scheme
@@ -2577,8 +2578,13 @@ module GFS_typedefs
 
     !--- microphysical switch
     Model%ncld             = ncld
+    !--- dynamical core parameters
+    Model%dycore_hydrostatic = hydro
     !--- GFDL microphysical parameters
     Model%do_sat_adj       = do_sat_adj
+    Model%do_inline_mp     = do_inline_mp
+    !--- The CFMIP Observation Simulator Package (COSP)
+    Model%do_cosp          = do_cosp
     !--- Zhao-Carr MP parameters
     Model%zhao_mic         = zhao_mic
     Model%psautco          = psautco

--- a/gsmphys/gfdl_cld_mp.F90
+++ b/gsmphys/gfdl_cld_mp.F90
@@ -327,6 +327,9 @@ module gfdl_cld_mp_mod
 
     logical :: do_subgrid_proc = .true. ! do temperature sentive high vertical resolution processes
 
+    logical :: fast_fr_mlt = .true. ! do freezing and melting in fast microphysics
+    logical :: fast_dep_sub = .true. ! do deposition and sublimation in fast microphysics
+
     real :: mp_time = 150.0 ! maximum microphysics time step (s)
 
     real :: n0w_sig = 1.1 ! intercept parameter (significand) of cloud water (Lin et al. 1983) (1/m^4) (Martin et al. 1994)
@@ -536,7 +539,8 @@ module gfdl_cld_mp_mod
         alinw, alini, alinr, alins, aling, alinh, blinw, blini, blinr, blins, bling, blinh, &
         do_new_acc_water, do_new_acc_ice, is_fac, ss_fac, gs_fac, rh_fac_evap, rh_fac_cond, &
         snow_grauple_combine, do_psd_water_num, do_psd_ice_num, vdiffflag, rewfac, reifac, &
-        cp_heating, nconds, do_evap_timescale, delay_cond_evap, do_subgrid_proc
+        cp_heating, nconds, do_evap_timescale, delay_cond_evap, do_subgrid_proc, &
+        fast_fr_mlt, fast_dep_sub
 
 contains
 
@@ -2006,7 +2010,7 @@ subroutine mp_fast (ks, ke, tz, qv, ql, qr, qi, qs, qg, dtm, dp, den, &
     call cal_mhc_lhc (ks, ke, qv, ql, qr, qi, qs, qg, q_liq, q_sol, cvm, te8, tz, &
         lcpk, icpk, tcpk, tcp3)
 
-    if (.not. do_warm_rain_mp) then
+    if (.not. do_warm_rain_mp .and. fast_fr_mlt) then
 
         ! -----------------------------------------------------------------------
         ! cloud ice melting to form cloud water and rain
@@ -2044,7 +2048,7 @@ subroutine mp_fast (ks, ke, tz, qv, ql, qr, qi, qs, qg, dtm, dp, den, &
     condensation = condensation + cond * convt
     evaporation = evaporation + reevap * convt
 
-    if (.not. do_warm_rain_mp) then
+    if (.not. do_warm_rain_mp .and. fast_fr_mlt) then
 
         ! -----------------------------------------------------------------------
         ! cloud water freezing to form cloud ice and snow
@@ -2089,7 +2093,7 @@ subroutine mp_fast (ks, ke, tz, qv, ql, qr, qi, qs, qg, dtm, dp, den, &
 
     call praut_simp (ks, ke, dtm, tz, qv, ql, qr, qi, qs, qg)
 
-    if (.not. do_warm_rain_mp) then
+    if (.not. do_warm_rain_mp .and. fast_dep_sub) then
 
         ! -----------------------------------------------------------------------
         ! cloud ice deposition and sublimation


### PR DESCRIPTION
**Description**

This PR and PR https://github.com/NOAA-GFDL/atmos_drivers/pull/24 address the following comment from the review of PR https://github.com/NOAA-GFDL/SHiELD_physics/pull/22:

"The designed way to get this information to the physics from outside is to use the GFS_init_type. This type is populated with dycore and other external to the physics information within the atmos_model.F90::atmos_model_init function and it is passed to GFS_Initialize, where it is passed to the Model%init procedure."

Fixes # (issue)

**How Has This Been Tested?**



**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
