### PR TITLE
Make `Diag` data structure public in FV3GFS_io.F90

### DIFF
--- a/FV3GFS/FV3GFS_io.F90
+++ b/FV3GFS/FV3GFS_io.F90
@@ -77,6 +77,7 @@ module FV3GFS_io_mod
   public  register_coarse_diag_manager_controlled_diagnostics
   public  send_diag_manager_controlled_diagnostic_data
   public  sfc_data_override
+  public  Diag
 
   !--- GFDL filenames
   character(len=32)  :: fn_oro = 'oro_data.nc'
@@ -113,7 +114,6 @@ module FV3GFS_io_mod
   end type data_subtype
   !--- data type definition for use with GFDL FMS diagnostic manager until write component is working
   type gfdl_diag_type
-    private
     integer :: id = -1
     integer :: axes = -1
     logical :: time_avg = .false.


### PR DESCRIPTION
**Description**

This PR implements the changes suggested in #29.  

Fixes #29

**How Has This Been Tested?**

This has been tested in CI in https://github.com/ai2cm/SHiELD-wrapper/pull/4 (see tests defined [here](https://github.com/ai2cm/SHiELD-wrapper/blob/3c5af7c7739359099fcbce707d32185ef8ecc2e8/wrapper/tests/test_diagnostics.py#L12-L47)).  The model compiles successfully and with updates to the wrapper we are able to successfully get values of the physics diagnostics during simulations.

**Checklist:**

Please check all whether they apply or not
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
