### PR TITLE
Add hooks for overriding surface radiative fluxes seen by land and ocean models

### DIFF
--- a/FV3GFS/FV3GFS_io.F90
+++ b/FV3GFS/FV3GFS_io.F90
@@ -4689,17 +4689,18 @@ module FV3GFS_io_mod
     if (override_surface_radiative_fluxes) then
       idx = idx + 1
       Diag(idx)%axes = 2
-      Diag(idx)%name = 'DLWRF_from_rrtmg'
+      Diag(idx)%name = 'DLWRFsfc_from_rrtmg'
       Diag(idx)%desc = 'Native RRTMG surface downward longwave flux'
       Diag(idx)%unit = 'W/m**2'
       Diag(idx)%mod_name = 'gfs_phys'
       Diag(idx)%cnvfac = cn_one
       Diag(idx)%time_avg = .TRUE.
+      Diag(idx)%time_avg_kind = 'rad_lw'
       Diag(idx)%intpl_method = 'bilinear'
       Diag(idx)%coarse_graining_method = 'area_weighted'
       allocate (Diag(idx)%data(nblks))
       do nb = 1,nblks
-        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfc(:)
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%fluxr(:,19)
       enddo
 
       idx = idx + 1
@@ -4717,17 +4718,18 @@ module FV3GFS_io_mod
 
       idx = idx + 1
       Diag(idx)%axes = 2
-      Diag(idx)%name = 'ULWRF_from_rrtmg'
+      Diag(idx)%name = 'ULWRFsfc_from_rrtmg'
       Diag(idx)%desc = 'Native RRTMG surface upward longwave flux'
       Diag(idx)%unit = 'W/m**2'
       Diag(idx)%mod_name = 'gfs_phys'
       Diag(idx)%cnvfac = cn_one
       Diag(idx)%time_avg = .TRUE.
+      Diag(idx)%time_avg_kind = 'rad_lw'
       Diag(idx)%intpl_method = 'bilinear'
       Diag(idx)%coarse_graining_method = 'area_weighted'
       allocate (Diag(idx)%data(nblks))
       do nb = 1,nblks
-        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%ulwsfc(:)
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%fluxr(:,20)
       enddo
 
       idx = idx + 1
@@ -4745,7 +4747,7 @@ module FV3GFS_io_mod
 
       idx = idx + 1
       Diag(idx)%axes = 2
-      Diag(idx)%name = 'DSWRF_from_rrtmg'
+      Diag(idx)%name = 'DSWRFsfc_from_rrtmg'
       Diag(idx)%desc = 'Native RRTMG averaged surface downward shortwave flux'
       Diag(idx)%unit = 'W/m**2'
       Diag(idx)%mod_name = 'gfs_phys'
@@ -4774,7 +4776,7 @@ module FV3GFS_io_mod
 
       idx = idx + 1
       Diag(idx)%axes = 2
-      Diag(idx)%name = 'USWRF_from_rrtmg'
+      Diag(idx)%name = 'USWRFsfc_from_rrtmg'
       Diag(idx)%desc = 'Native RRTMG averaged surface upward shortwave flux'
       Diag(idx)%unit = 'W/m**2'
       Diag(idx)%mod_name = 'gfs_phys'

--- a/FV3GFS/FV3GFS_io.F90
+++ b/FV3GFS/FV3GFS_io.F90
@@ -3083,84 +3083,51 @@ module FV3GFS_io_mod
     idx = idx + 1
     Diag(idx)%axes = 2
     Diag(idx)%name = 'USWRFsfc'
-    Diag(idx)%desc = 'averaged surface upward shortwave flux'
+    Diag(idx)%desc = 'Interval-averaged unadjusted upward shortwave flux at the surface'
     Diag(idx)%unit = 'W/m**2'
     Diag(idx)%mod_name = 'gfs_phys'
     Diag(idx)%cnvfac = cn_one
     Diag(idx)%time_avg = .TRUE.
-    if (.not. override_surface_radiative_fluxes) then
-      Diag(idx)%time_avg_kind = 'rad_sw'
-    endif
+    Diag(idx)%time_avg_kind = 'rad_sw'
     Diag(idx)%intpl_method = 'bilinear'
     allocate (Diag(idx)%data(nblks))
-    ! This diagnostic is always meant to refer to what the model felt, so it
-    ! refers to the override flux when overriding and the RRTMG flux when not.
-    ! Note the time_avg_kind (above) is special when not overriding.
-    if (override_surface_radiative_fluxes) then
-      do nb = 1,nblks
-        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswsfc_override(:)
-      enddo
-    else
-      do nb = 1,nblks
-        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%fluxr(:,3)
-      enddo
-    endif
+    do nb = 1,nblks
+      Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%fluxr(:,3)
+    enddo
 
     idx = idx + 1
     Diag(idx)%axes = 2
     Diag(idx)%name = 'DSWRFsfc'
-    Diag(idx)%desc = 'averaged surface downward shortwave flux'
+    Diag(idx)%desc = 'Interval-averaged unadjusted downward shortwave flux at the surface'
     Diag(idx)%unit = 'W/m**2'
     Diag(idx)%mod_name = 'gfs_phys'
     Diag(idx)%cnvfac = cn_one
     Diag(idx)%time_avg = .TRUE.
-    if (.not. override_surface_radiative_fluxes) then
-      Diag(idx)%time_avg_kind = 'rad_sw'
-    endif
+    Diag(idx)%time_avg_kind = 'rad_sw'
     Diag(idx)%intpl_method = 'bilinear'
     allocate (Diag(idx)%data(nblks))
-    ! This diagnostic is always meant to refer to what the model felt, so it
-    ! refers to the override flux when overriding and the RRTMG flux when not.
-    ! Note the time_avg_kind (above) is special when not overriding.
-    if (override_surface_radiative_fluxes) then
-      do nb = 1,nblks
-        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswsfc_override(:)
-      enddo
-    else
-      do nb = 1,nblks
-        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%fluxr(:,4)
-      enddo
-    endif
+    do nb = 1,nblks
+      Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%fluxr(:,4)
+    enddo
 
     idx = idx + 1
     Diag(idx)%axes = 2
     Diag(idx)%name = 'DLWRFsfc'
-    Diag(idx)%desc = 'surface downward longwave flux [W/m**2]'
+    Diag(idx)%desc = 'Interval-averaged unadjusted downward longwave flux at the surface'
     Diag(idx)%unit = 'W/m**2'
     Diag(idx)%mod_name = 'gfs_phys'
     Diag(idx)%cnvfac = cn_one
     Diag(idx)%time_avg = .TRUE.
-    if (.not. override_surface_radiative_fluxes) then
-      Diag(idx)%time_avg_kind = 'rad_lw'
-    endif
+    Diag(idx)%time_avg_kind = 'rad_lw'
     allocate (Diag(idx)%data(nblks))
-    ! This diagnostic is always meant to refer to what the model felt, so it
-    ! refers to the override flux when overriding and the RRTMG flux when not.
-    ! Note the time_avg_kind (above) is special when not overriding.
-    if (override_surface_radiative_fluxes) then
-      do nb = 1,nblks
-        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfc_override(:)
-      enddo
-    else
-      do nb = 1,nblks
-        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%fluxr(:,19)
-      enddo
-    endif
+    do nb = 1,nblks
+      Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%fluxr(:,19)
+    enddo
 
     idx = idx + 1
     Diag(idx)%axes = 2
     Diag(idx)%name = 'ULWRFsfc'
-    Diag(idx)%desc = 'surface upward longwave flux [W/m**2]'
+    Diag(idx)%desc = 'Interval-averaged unadjusted upward longwave flux at the surface'
     Diag(idx)%unit = 'W/m**2'
     Diag(idx)%mod_name = 'gfs_phys'
     Diag(idx)%cnvfac = cn_one
@@ -3971,22 +3938,74 @@ module FV3GFS_io_mod
 
     idx = idx + 1
     Diag(idx)%axes = 2
-    Diag(idx)%name = 'DLWRF'
-    Diag(idx)%desc = 'time accumulated downward lw flux at surface- GFS physics'
+    Diag(idx)%name = 'DSWRF'
+    Diag(idx)%desc = 'Interval-averaged zenith-angle-adjusted downward shortwave flux at the surface'
     Diag(idx)%unit = 'w/m**2'
     Diag(idx)%mod_name = 'gfs_phys'
     Diag(idx)%cnvfac = cn_one
     Diag(idx)%time_avg = .TRUE.
     Diag(idx)%intpl_method = 'bilinear'
     allocate (Diag(idx)%data(nblks))
-    do nb = 1,nblks
-      Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfc(:)
-    enddo
+    ! This diagnostic is always meant to refer to what the model felt, so it
+    ! refers to the override flux when overriding and the RRTMG flux when not.
+    if (override_surface_radiative_fluxes) then
+      do nb = 1,nblks
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswsfc_override(:)
+      enddo
+    else
+      do nb = 1,nblks
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswsfc(:)
+      enddo
+    endif
+
+    idx = idx + 1
+    Diag(idx)%axes = 2
+    Diag(idx)%name = 'USWRF'
+    Diag(idx)%desc = 'Interval-averaged zenith-angle-adjusted upward shortwave flux at the surface'
+    Diag(idx)%unit = 'w/m**2'
+    Diag(idx)%mod_name = 'gfs_phys'
+    Diag(idx)%cnvfac = cn_one
+    Diag(idx)%time_avg = .TRUE.
+    Diag(idx)%intpl_method = 'bilinear'
+    allocate (Diag(idx)%data(nblks))
+    ! This diagnostic is always meant to refer to what the model felt, so it
+    ! refers to the override flux when overriding and the RRTMG flux when not.
+    if (override_surface_radiative_fluxes) then
+      do nb = 1,nblks
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswsfc_override(:)
+      enddo
+    else
+      do nb = 1,nblks
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswsfc(:)
+      enddo
+    endif
+
+    idx = idx + 1
+    Diag(idx)%axes = 2
+    Diag(idx)%name = 'DLWRF'
+    Diag(idx)%desc = 'Interval-averaged surface-temperature-adjusted downward longwave flux at the surface'
+    Diag(idx)%unit = 'w/m**2'
+    Diag(idx)%mod_name = 'gfs_phys'
+    Diag(idx)%cnvfac = cn_one
+    Diag(idx)%time_avg = .TRUE.
+    Diag(idx)%intpl_method = 'bilinear'
+    allocate (Diag(idx)%data(nblks))
+    ! This diagnostic is always meant to refer to what the model felt, so it
+    ! refers to the override flux when overriding and the RRTMG flux when not.
+    if (override_surface_radiative_fluxes) then
+      do nb = 1,nblks
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfc_override(:)
+      enddo
+    else
+      do nb = 1,nblks
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfc(:)
+      enddo
+    endif
 
     idx = idx + 1
     Diag(idx)%axes = 2
     Diag(idx)%name = 'ULWRF'
-    Diag(idx)%desc = 'time accumulated upward lw flux at surface- GFS physics'
+    Diag(idx)%desc = 'Interval-averaged surface-temperature-adjusted upward longwave flux at the surface'
     Diag(idx)%unit = 'w/m**2'
     Diag(idx)%mod_name = 'gfs_phys'
     Diag(idx)%cnvfac = cn_one
@@ -4617,7 +4636,7 @@ module FV3GFS_io_mod
     idx = idx + 1
     Diag(idx)%axes = 2
     Diag(idx)%name = 'DLWRFI'
-    Diag(idx)%desc = 'instantaneous sfc downward lw flux'
+    Diag(idx)%desc = 'Instantaneous surface-temperature-adjusted downward longwave flux at the surface'
     Diag(idx)%unit = 'w/m**2'
     Diag(idx)%mod_name = 'gfs_phys'
     Diag(idx)%intpl_method = 'bilinear'
@@ -4637,7 +4656,7 @@ module FV3GFS_io_mod
     idx = idx + 1
     Diag(idx)%axes = 2
     Diag(idx)%name = 'ULWRFI'
-    Diag(idx)%desc = 'instantaneous sfc upward lw flux'
+    Diag(idx)%desc = 'Instantaneous surface-temperature-adjusted upward longwave flux at the surface'
     Diag(idx)%unit = 'w/m**2'
     Diag(idx)%mod_name = 'gfs_phys'
     Diag(idx)%intpl_method = 'bilinear'
@@ -4649,7 +4668,7 @@ module FV3GFS_io_mod
     idx = idx + 1
     Diag(idx)%axes = 2
     Diag(idx)%name = 'DSWRFI'
-    Diag(idx)%desc = 'instantaneous sfc downward sw flux'
+    Diag(idx)%desc = 'Instantaneous zenith-angle-adjusted downward shortwave flux at the surface'
     Diag(idx)%unit = 'w/m**2'
     Diag(idx)%mod_name = 'gfs_phys'
     Diag(idx)%intpl_method = 'bilinear'
@@ -4669,7 +4688,7 @@ module FV3GFS_io_mod
     idx = idx + 1
     Diag(idx)%axes = 2
     Diag(idx)%name = 'USWRFI'
-    Diag(idx)%desc = 'instantaneous sfc upward sw flux'
+    Diag(idx)%desc = 'Instantaneous zenith-angle-adjusted upward shortwave flux at the surface'
     Diag(idx)%unit = 'w/m**2'
     Diag(idx)%mod_name = 'gfs_phys'
     Diag(idx)%intpl_method = 'bilinear'
@@ -4689,24 +4708,23 @@ module FV3GFS_io_mod
     if (override_surface_radiative_fluxes) then
       idx = idx + 1
       Diag(idx)%axes = 2
-      Diag(idx)%name = 'DLWRFsfc_from_rrtmg'
-      Diag(idx)%desc = 'Native RRTMG surface downward longwave flux'
+      Diag(idx)%name = 'DLWRF_from_rrtmg'
+      Diag(idx)%desc = 'Interval-averaged native RRTMG surface-temperature-adjusted downward longwave flux at the surface'
       Diag(idx)%unit = 'W/m**2'
       Diag(idx)%mod_name = 'gfs_phys'
       Diag(idx)%cnvfac = cn_one
       Diag(idx)%time_avg = .TRUE.
-      Diag(idx)%time_avg_kind = 'rad_lw'
       Diag(idx)%intpl_method = 'bilinear'
       Diag(idx)%coarse_graining_method = 'area_weighted'
       allocate (Diag(idx)%data(nblks))
       do nb = 1,nblks
-        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%fluxr(:,19)
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfc(:)
       enddo
 
       idx = idx + 1
       Diag(idx)%axes = 2
       Diag(idx)%name = 'DLWRFI_from_rrtmg'
-      Diag(idx)%desc = 'Native RRTMG instantaneous surface downward longwave flux'
+      Diag(idx)%desc = 'Instantaneous native RRTMG surface-temperature-adjusted downward longwave flux at the surface'
       Diag(idx)%unit = 'W/m**2'
       Diag(idx)%mod_name = 'gfs_phys'
       Diag(idx)%intpl_method = 'bilinear'
@@ -4718,24 +4736,23 @@ module FV3GFS_io_mod
 
       idx = idx + 1
       Diag(idx)%axes = 2
-      Diag(idx)%name = 'ULWRFsfc_from_rrtmg'
-      Diag(idx)%desc = 'Native RRTMG surface upward longwave flux'
+      Diag(idx)%name = 'ULWRF_from_rrtmg'
+      Diag(idx)%desc = 'Interval-averaged native RRTMG surface-temperature-adjusted upward longwave flux at the surface'
       Diag(idx)%unit = 'W/m**2'
       Diag(idx)%mod_name = 'gfs_phys'
       Diag(idx)%cnvfac = cn_one
       Diag(idx)%time_avg = .TRUE.
-      Diag(idx)%time_avg_kind = 'rad_lw'
       Diag(idx)%intpl_method = 'bilinear'
       Diag(idx)%coarse_graining_method = 'area_weighted'
       allocate (Diag(idx)%data(nblks))
       do nb = 1,nblks
-        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%fluxr(:,20)
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%ulwsfc(:)
       enddo
 
       idx = idx + 1
       Diag(idx)%axes = 2
       Diag(idx)%name = 'ULWRFI_from_rrtmg'
-      Diag(idx)%desc = 'Native RRTMG instantaneous surface upward longwave flux'
+      Diag(idx)%desc = 'Instantaneous native RRTMG surface-temperature-adjusted upward longwave flux at the surface'
       Diag(idx)%unit = 'W/m**2'
       Diag(idx)%mod_name = 'gfs_phys'
       Diag(idx)%intpl_method = 'bilinear'
@@ -4747,24 +4764,23 @@ module FV3GFS_io_mod
 
       idx = idx + 1
       Diag(idx)%axes = 2
-      Diag(idx)%name = 'DSWRFsfc_from_rrtmg'
-      Diag(idx)%desc = 'Native RRTMG averaged surface downward shortwave flux'
+      Diag(idx)%name = 'DSWRF_from_rrtmg'
+      Diag(idx)%desc = 'Interval-averaged native RRTMG zenith-angle-adjusted downward shortwave flux at the surface'
       Diag(idx)%unit = 'W/m**2'
       Diag(idx)%mod_name = 'gfs_phys'
       Diag(idx)%cnvfac = cn_one
       Diag(idx)%time_avg = .TRUE.
-      Diag(idx)%time_avg_kind = 'rad_sw'
       Diag(idx)%intpl_method = 'bilinear'
       Diag(idx)%coarse_graining_method = 'area_weighted'
       allocate (Diag(idx)%data(nblks))
       do nb = 1,nblks
-        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%fluxr(:,4)
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswsfc(:)
       enddo
 
       idx = idx + 1
       Diag(idx)%axes = 2
       Diag(idx)%name = 'DSWRFI_from_rrtmg'
-      Diag(idx)%desc = 'Native RRTMG instantaneous surface downward shortwave flux'
+      Diag(idx)%desc = 'Instantaneous native RRTMG zenith-angle-adjusted downward shortwave flux at the surface'
       Diag(idx)%unit = 'W/m**2'
       Diag(idx)%mod_name = 'gfs_phys'
       Diag(idx)%intpl_method = 'bilinear'
@@ -4776,24 +4792,23 @@ module FV3GFS_io_mod
 
       idx = idx + 1
       Diag(idx)%axes = 2
-      Diag(idx)%name = 'USWRFsfc_from_rrtmg'
-      Diag(idx)%desc = 'Native RRTMG averaged surface upward shortwave flux'
+      Diag(idx)%name = 'USWRF_from_rrtmg'
+      Diag(idx)%desc = 'Interval-averaged native RRTMG zenith-angle-adjusted upward shortwave flux at the surface'
       Diag(idx)%unit = 'W/m**2'
       Diag(idx)%mod_name = 'gfs_phys'
       Diag(idx)%cnvfac = cn_one
       Diag(idx)%time_avg = .TRUE.
-      Diag(idx)%time_avg_kind = 'rad_sw'
       Diag(idx)%intpl_method = 'bilinear'
       Diag(idx)%coarse_graining_method = 'area_weighted'
       allocate (Diag(idx)%data(nblks))
       do nb = 1,nblks
-        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%fluxr(:,3)
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswsfc(:)
       enddo
 
       idx = idx + 1
       Diag(idx)%axes = 2
       Diag(idx)%name = 'USWRFI_from_rrtmg'
-      Diag(idx)%desc = 'Native RRTMG instantaneous surface upward shortwave flux'
+      Diag(idx)%desc = 'Instantaneous native RRTMG zenith-angle-adjusted upward shortwave flux at the surface'
       Diag(idx)%unit = 'W/m**2'
       Diag(idx)%mod_name = 'gfs_phys'
       Diag(idx)%intpl_method = 'bilinear'

--- a/FV3GFS/FV3GFS_io.F90
+++ b/FV3GFS/FV3GFS_io.F90
@@ -3093,9 +3093,12 @@ module FV3GFS_io_mod
     endif
     Diag(idx)%intpl_method = 'bilinear'
     allocate (Diag(idx)%data(nblks))
+    ! This diagnostic is always meant to refer to what the model felt, so it
+    ! refers to the override flux when overriding and the RRTMG flux when not.
+    ! Note the time_avg_kind (above) is special when not overriding.
     if (override_surface_radiative_fluxes) then
       do nb = 1,nblks
-        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswsfc(:)
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswsfc_override(:)
       enddo
     else
       do nb = 1,nblks
@@ -3116,9 +3119,12 @@ module FV3GFS_io_mod
     endif
     Diag(idx)%intpl_method = 'bilinear'
     allocate (Diag(idx)%data(nblks))
+    ! This diagnostic is always meant to refer to what the model felt, so it
+    ! refers to the override flux when overriding and the RRTMG flux when not.
+    ! Note the time_avg_kind (above) is special when not overriding.
     if (override_surface_radiative_fluxes) then
       do nb = 1,nblks
-        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswsfc(:)
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswsfc_override(:)
       enddo
     else
       do nb = 1,nblks
@@ -3138,9 +3144,12 @@ module FV3GFS_io_mod
       Diag(idx)%time_avg_kind = 'rad_lw'
     endif
     allocate (Diag(idx)%data(nblks))
+    ! This diagnostic is always meant to refer to what the model felt, so it
+    ! refers to the override flux when overriding and the RRTMG flux when not.
+    ! Note the time_avg_kind (above) is special when not overriding.
     if (override_surface_radiative_fluxes) then
       do nb = 1,nblks
-        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfc(:)
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfc_override(:)
       enddo
     else
       do nb = 1,nblks
@@ -4613,9 +4622,17 @@ module FV3GFS_io_mod
     Diag(idx)%mod_name = 'gfs_phys'
     Diag(idx)%intpl_method = 'bilinear'
     allocate (Diag(idx)%data(nblks))
-    do nb = 1,nblks
-      Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfci(:)
-    enddo
+    ! This diagnostic is always meant to refer to what the model felt, so it
+    ! refers to the override flux when overriding and the RRTMG flux when not.
+    if (override_surface_radiative_fluxes) then
+      do nb = 1,nblks
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfci_override(:)
+      enddo
+    else
+      do nb = 1,nblks
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfci(:)
+      enddo
+    endif
 
     idx = idx + 1
     Diag(idx)%axes = 2
@@ -4637,9 +4654,17 @@ module FV3GFS_io_mod
     Diag(idx)%mod_name = 'gfs_phys'
     Diag(idx)%intpl_method = 'bilinear'
     allocate (Diag(idx)%data(nblks))
-    do nb = 1,nblks
-      Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswsfci(:)
-    enddo
+    ! This diagnostic is always meant to refer to what the model felt, so it
+    ! refers to the override flux when overriding and the RRTMG flux when not.
+    if (override_surface_radiative_fluxes) then
+      do nb = 1,nblks
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswsfci_override(:)
+      enddo
+    else
+      do nb = 1,nblks
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswsfci(:)
+      enddo
+    endif
 
     idx = idx + 1
     Diag(idx)%axes = 2
@@ -4649,15 +4674,23 @@ module FV3GFS_io_mod
     Diag(idx)%mod_name = 'gfs_phys'
     Diag(idx)%intpl_method = 'bilinear'
     allocate (Diag(idx)%data(nblks))
-    do nb = 1,nblks
-      Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswsfci(:)
-    enddo
+    ! This diagnostic is always meant to refer to what the model felt, so it
+    ! refers to the override flux when overriding and the RRTMG flux when not.
+    if (override_surface_radiative_fluxes) then
+      do nb = 1,nblks
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswsfci_override(:)
+      enddo
+    else
+      do nb = 1,nblks
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswsfci(:)
+      enddo
+    endif
 
     if (override_surface_radiative_fluxes) then
       idx = idx + 1
       Diag(idx)%axes = 2
       Diag(idx)%name = 'DLWRF_from_rrtmg'
-      Diag(idx)%desc = 'surface downward longwave flux due to RRTMG'
+      Diag(idx)%desc = 'Native RRTMG surface downward longwave flux'
       Diag(idx)%unit = 'W/m**2'
       Diag(idx)%mod_name = 'gfs_phys'
       Diag(idx)%cnvfac = cn_one
@@ -4666,27 +4699,26 @@ module FV3GFS_io_mod
       Diag(idx)%coarse_graining_method = 'area_weighted'
       allocate (Diag(idx)%data(nblks))
       do nb = 1,nblks
-        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfc_rrtmg(:)
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfc(:)
       enddo
 
       idx = idx + 1
       Diag(idx)%axes = 2
       Diag(idx)%name = 'DLWRFI_from_rrtmg'
-      Diag(idx)%desc = 'instantaneous surface downward longwave flux due to RRTMG'
+      Diag(idx)%desc = 'Native RRTMG instantaneous surface downward longwave flux'
       Diag(idx)%unit = 'W/m**2'
       Diag(idx)%mod_name = 'gfs_phys'
       Diag(idx)%intpl_method = 'bilinear'
       Diag(idx)%coarse_graining_method = 'area_weighted'
       allocate (Diag(idx)%data(nblks))
       do nb = 1,nblks
-        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfci_rrtmg(:)
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfci(:)
       enddo
-
 
       idx = idx + 1
       Diag(idx)%axes = 2
       Diag(idx)%name = 'ULWRF_from_rrtmg'
-      Diag(idx)%desc = 'surface upward longwave flux due to RRTMG'
+      Diag(idx)%desc = 'Native RRTMG surface upward longwave flux'
       Diag(idx)%unit = 'W/m**2'
       Diag(idx)%mod_name = 'gfs_phys'
       Diag(idx)%cnvfac = cn_one
@@ -4695,26 +4727,26 @@ module FV3GFS_io_mod
       Diag(idx)%coarse_graining_method = 'area_weighted'
       allocate (Diag(idx)%data(nblks))
       do nb = 1,nblks
-        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%ulwsfc_rrtmg(:)
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%ulwsfc(:)
       enddo
 
       idx = idx + 1
       Diag(idx)%axes = 2
       Diag(idx)%name = 'ULWRFI_from_rrtmg'
-      Diag(idx)%desc = 'instantaneous surface upward longwave flux due to RRTMG'
+      Diag(idx)%desc = 'Native RRTMG instantaneous surface upward longwave flux'
       Diag(idx)%unit = 'W/m**2'
       Diag(idx)%mod_name = 'gfs_phys'
       Diag(idx)%intpl_method = 'bilinear'
       Diag(idx)%coarse_graining_method = 'area_weighted'
       allocate (Diag(idx)%data(nblks))
       do nb = 1,nblks
-        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%ulwsfci_rrtmg(:)
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%ulwsfci(:)
       enddo
 
       idx = idx + 1
       Diag(idx)%axes = 2
       Diag(idx)%name = 'DSWRF_from_rrtmg'
-      Diag(idx)%desc = 'averaged surface downward shortwave flux due to RRTMG'
+      Diag(idx)%desc = 'Native RRTMG averaged surface downward shortwave flux'
       Diag(idx)%unit = 'W/m**2'
       Diag(idx)%mod_name = 'gfs_phys'
       Diag(idx)%cnvfac = cn_one
@@ -4730,20 +4762,20 @@ module FV3GFS_io_mod
       idx = idx + 1
       Diag(idx)%axes = 2
       Diag(idx)%name = 'DSWRFI_from_rrtmg'
-      Diag(idx)%desc = 'instantaneous surface downward shortwave flux due to RRTMG'
+      Diag(idx)%desc = 'Native RRTMG instantaneous surface downward shortwave flux'
       Diag(idx)%unit = 'W/m**2'
       Diag(idx)%mod_name = 'gfs_phys'
       Diag(idx)%intpl_method = 'bilinear'
       Diag(idx)%coarse_graining_method = 'area_weighted'
       allocate (Diag(idx)%data(nblks))
       do nb = 1,nblks
-        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswsfci_rrtmg(:)
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswsfci(:)
       enddo
 
       idx = idx + 1
       Diag(idx)%axes = 2
       Diag(idx)%name = 'USWRF_from_rrtmg'
-      Diag(idx)%desc = 'averaged surface upward shortwave flux due to RRTMG'
+      Diag(idx)%desc = 'Native RRTMG averaged surface upward shortwave flux'
       Diag(idx)%unit = 'W/m**2'
       Diag(idx)%mod_name = 'gfs_phys'
       Diag(idx)%cnvfac = cn_one
@@ -4759,14 +4791,14 @@ module FV3GFS_io_mod
       idx = idx + 1
       Diag(idx)%axes = 2
       Diag(idx)%name = 'USWRFI_from_rrtmg'
-      Diag(idx)%desc = 'instantaneous surface upward shortwave flux due to RRTMG'
+      Diag(idx)%desc = 'Native RRTMG instantaneous surface upward shortwave flux'
       Diag(idx)%unit = 'W/m**2'
       Diag(idx)%mod_name = 'gfs_phys'
       Diag(idx)%intpl_method = 'bilinear'
       Diag(idx)%coarse_graining_method = 'area_weighted'
       allocate (Diag(idx)%data(nblks))
       do nb = 1,nblks
-        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswsfci_rrtmg(:)
+        Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswsfci(:)
       enddo
     endif
 

--- a/GFS_layer/GFS_abstraction_layer.F90
+++ b/GFS_layer/GFS_abstraction_layer.F90
@@ -11,7 +11,7 @@ module physics_abstraction_layer
                              cldprop_type     =>  GFS_cldprop_type,  &
                              radtend_type     =>  GFS_radtend_type,  &
                              intdiag_type     =>  GFS_diag_type,     &
-                             overrides_from_python_wrapper_type => GFS_overrides_from_python_wrapper_type
+                             overrides_type   =>  GFS_overrides_type
 
   use GFS_driver,      only: initialize       =>  GFS_initialize,       &
                              time_vary_step   =>  GFS_time_vary_step,   &

--- a/GFS_layer/GFS_abstraction_layer.F90
+++ b/GFS_layer/GFS_abstraction_layer.F90
@@ -10,7 +10,8 @@ module physics_abstraction_layer
                              tbd_type         =>  GFS_tbd_type,      &
                              cldprop_type     =>  GFS_cldprop_type,  &
                              radtend_type     =>  GFS_radtend_type,  &
-                             intdiag_type     =>  GFS_diag_type
+                             intdiag_type     =>  GFS_diag_type,     &
+                             overrides_from_python_wrapper_type => GFS_overrides_from_python_wrapper_type
 
   use GFS_driver,      only: initialize       =>  GFS_initialize,       &
                              time_vary_step   =>  GFS_time_vary_step,   &

--- a/GFS_layer/GFS_driver.F90
+++ b/GFS_layer/GFS_driver.F90
@@ -6,7 +6,8 @@ module GFS_driver
                                       GFS_sfcprop_type, GFS_coupling_type, &
                                       GFS_control_type, GFS_grid_type,     &
                                       GFS_tbd_type,     GFS_cldprop_type,  &
-                                      GFS_radtend_type, GFS_diag_type
+                                      GFS_radtend_type, GFS_diag_type,     &
+                                      GFS_overrides_from_python_wrapper_type
   use module_radiation_driver,  only: GFS_radiation_driver, radupdate
   use module_physics_driver,    only: GFS_physics_driver
   use module_radsw_parameters,  only: topfsw_type, sfcfsw_type
@@ -106,7 +107,7 @@ module GFS_driver
 !--------------
   subroutine GFS_initialize (Model, Statein, Stateout, Sfcprop,    &
                              Coupling, Grid, Tbd, Cldprop, Radtend, &
-                             Diag, Init_parm)
+                             Diag, OverridesFromPythonWrapper, Init_parm)
 
     use module_microphysics, only: gsmconst
     use cldwat2m_micro,      only: ini_micro
@@ -125,6 +126,7 @@ module GFS_driver
     type(GFS_cldprop_type),   intent(inout) :: Cldprop(:)
     type(GFS_radtend_type),   intent(inout) :: Radtend(:)
     type(GFS_diag_type),      intent(inout) :: Diag(:)
+    type(GFS_overrides_from_python_wrapper_type), intent(inout) :: OverridesFromPythonWrapper(:)
     type(GFS_init_type),      intent(in)    :: Init_parm
 
     !--- local variables
@@ -170,6 +172,7 @@ module GFS_driver
       call Radtend  (nb)%create (Init_parm%blksz(nb), Model)
       !--- internal representation of diagnostics
       call Diag     (nb)%create (Init_parm%blksz(nb), Model)
+      call OverridesFromPythonWrapper(nb)%create (Init_parm%blksz(nb), Model)
     enddo
 
     !--- populate the grid components

--- a/GFS_layer/GFS_driver.F90
+++ b/GFS_layer/GFS_driver.F90
@@ -7,7 +7,7 @@ module GFS_driver
                                       GFS_control_type, GFS_grid_type,     &
                                       GFS_tbd_type,     GFS_cldprop_type,  &
                                       GFS_radtend_type, GFS_diag_type,     &
-                                      GFS_overrides_from_python_wrapper_type
+                                      GFS_overrides_type
   use module_radiation_driver,  only: GFS_radiation_driver, radupdate
   use module_physics_driver,    only: GFS_physics_driver
   use module_radsw_parameters,  only: topfsw_type, sfcfsw_type
@@ -107,7 +107,7 @@ module GFS_driver
 !--------------
   subroutine GFS_initialize (Model, Statein, Stateout, Sfcprop,    &
                              Coupling, Grid, Tbd, Cldprop, Radtend, &
-                             Diag, OverridesFromPythonWrapper, Init_parm)
+                             Diag, Overrides, Init_parm)
 
     use module_microphysics, only: gsmconst
     use cldwat2m_micro,      only: ini_micro
@@ -126,7 +126,7 @@ module GFS_driver
     type(GFS_cldprop_type),   intent(inout) :: Cldprop(:)
     type(GFS_radtend_type),   intent(inout) :: Radtend(:)
     type(GFS_diag_type),      intent(inout) :: Diag(:)
-    type(GFS_overrides_from_python_wrapper_type), intent(inout) :: OverridesFromPythonWrapper(:)
+    type(GFS_overrides_type), intent(inout) :: Overrides(:)
     type(GFS_init_type),      intent(in)    :: Init_parm
 
     !--- local variables
@@ -172,7 +172,7 @@ module GFS_driver
       call Radtend  (nb)%create (Init_parm%blksz(nb), Model)
       !--- internal representation of diagnostics
       call Diag     (nb)%create (Init_parm%blksz(nb), Model)
-      call OverridesFromPythonWrapper(nb)%create (Init_parm%blksz(nb), Model)
+      call Overrides(nb)%create (Init_parm%blksz(nb), Model)
     enddo
 
     !--- populate the grid components

--- a/GFS_layer/GFS_physics_driver.F90
+++ b/GFS_layer/GFS_physics_driver.F90
@@ -14,7 +14,8 @@ module module_physics_driver
                                    GFS_sfcprop_type, GFS_coupling_type, &
                                    GFS_control_type, GFS_grid_type,     &
                                    GFS_tbd_type,     GFS_cldprop_type,  &
-                                   GFS_radtend_type, GFS_diag_type
+                                   GFS_radtend_type, GFS_diag_type,     &
+                                   GFS_overrides_from_python_wrapper_type
   use gfdl_cld_mp_mod,       only: gfdl_cld_mp_driver, cld_sat_adj, c_liq, c_ice
   use funcphys,              only: ftdp
   use module_ocean,          only: update_ocean
@@ -397,7 +398,7 @@ module module_physics_driver
 
     subroutine GFS_physics_driver                         &
          (Model, Statein, Stateout, Sfcprop, Coupling,  &
-          Grid, Tbd, Cldprop, Radtend, Diag)
+          Grid, Tbd, Cldprop, Radtend, Diag, OverridesFromPythonWrapper)
 
       implicit none
 !
@@ -412,6 +413,7 @@ module module_physics_driver
       type(GFS_cldprop_type),         intent(inout) :: Cldprop
       type(GFS_radtend_type),         intent(inout) :: Radtend
       type(GFS_diag_type),            intent(inout) :: Diag
+      type(GFS_overrides_from_python_wrapper_type), intent(inout) :: OverridesFromPythonWrapper
 !
 !  ---  local variables
 
@@ -620,9 +622,9 @@ module module_physics_driver
       endif
       
       if (Model%override_surface_radiative_fluxes) then
-        adjsfcdlw_for_lsm => Statein%adjsfcdlw_override
-        adjsfcdsw_for_lsm => Statein%adjsfcdsw_override
-        adjsfcnsw_for_lsm => Statein%adjsfcnsw_override
+        adjsfcdlw_for_lsm => OverridesFromPythonWrapper%adjsfcdlw_override
+        adjsfcdsw_for_lsm => OverridesFromPythonWrapper%adjsfcdsw_override
+        adjsfcnsw_for_lsm => OverridesFromPythonWrapper%adjsfcnsw_override
       else
         adjsfcdlw_for_lsm => adjsfcdlw
         adjsfcdsw_for_lsm => adjsfcdsw

--- a/GFS_layer/GFS_physics_driver.F90
+++ b/GFS_layer/GFS_physics_driver.F90
@@ -1418,13 +1418,15 @@ module module_physics_driver
 
       Diag%epi(:)     = ep1d(:)
 
-      ! Diag%dlwsfci, Diag%uswsfci, and Diag%dswsfci are always meant to refer
-      ! to RRTMG fluxes, so we do not use the adjsfc??w_for_coupling pointers
-      ! here.
+      ! Diag%dlwsfci, Diag%uswsfci, Diag%dswsfci, Diag%uswsfc, and Diag%dswsfc
+      ! are always meant to refer to RRTMG fluxes, so we do not use the
+      ! adjsfc??w_for_coupling pointers here.
       Diag%dlwsfci(:) = adjsfcdlw(:)
       Diag%ulwsfci(:) = adjsfculw(:)
       Diag%uswsfci(:) = adjsfcdsw(:) - adjsfcnsw(:)
       Diag%dswsfci(:) = adjsfcdsw(:)
+      Diag%uswsfc(:) =  Diag%uswsfc(:) + (adjsfcdsw(:) - adjsfcnsw(:))*dtf
+      Diag%dswsfc(:) =  Diag%dswsfc(:) + adjsfcdsw(:)*dtf
       Diag%gfluxi(:)  = gflx(:)
       Diag%t1(:)      = Statein%tgrs(:,1)
       Diag%q1(:)      = Statein%qgrs(:,1,1)

--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -1335,13 +1335,16 @@ module GFS_typedefs
 !  Container with variables used for overriding fields in the
 !  GFS_physics_driver from a Python-wrapped version of the model.
 !
-!  Currently the only supported variables for overriding are the
-!  downward longwave, downward shortwave, and net shortwave
-!  radiative fluxes at the surface seen by the land surface model.
-!  Memory will only be allocated for these variables, and they will
-!  only be used for overriding, if
-!  gfs_physics_nml.override_surface_radiative_fluxes is set to
-!  .true..
+!  Currently the only supported variables for overriding are the downward
+!  longwave, downward shortwave, and net shortwave radiative fluxes at the
+!  surface seen by the ocean and/or land surface model.  Memory will only be
+!  allocated for these variables, and they will only be used for overriding, if
+!  gfs_physics_nml.override_surface_radiative_fluxes is set to .true..
+!
+!  Note that from the perspective of the fortran code, these variables will
+!  appear to never be populated with anything other than zeros.  This is because
+!  they are expected to be populated within a wrapping model, which has the ability
+!  to set the state of the running fortran model within each timestep.
 !----------------------------------------------------------------
   type GFS_overrides_from_python_wrapper_type
     real (kind=kind_phys), pointer :: adjsfcdlw_override(:) => null()  !< override to the downward longwave radiation flux at the surface

--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -1197,6 +1197,8 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: gflux  (:)    => null()   !< groud conductive heat flux
     real (kind=kind_phys), pointer :: dlwsfc (:)    => null()   !< time accumulated sfc dn lw flux ( w/m**2 )
     real (kind=kind_phys), pointer :: ulwsfc (:)    => null()   !< time accumulated sfc up lw flux ( w/m**2 )
+    real (kind=kind_phys), pointer :: dswsfc (:)    => null()   !< time accumulated sfc dn sw flux ( w/m**2 )
+    real (kind=kind_phys), pointer :: uswsfc (:)    => null()   !< time accumulated sfc up sw flux ( w/m**2 )
     real (kind=kind_phys), pointer :: dlwsfc_override (:) => null()   !< time accumulated sfc dn lw flux ( w/m**2 ) when gfs_physics_nml.override_surface_radiative_fluxes == .true.
     real (kind=kind_phys), pointer :: dswsfc_override (:) => null()   !< time accumulated sfc dn sw flux ( w/m**2 ) when gfs_physics_nml.override_surface_radiative_fluxes == .true.
     real (kind=kind_phys), pointer :: uswsfc_override (:) => null()   !< time accumulated sfc up sw flux ( w/m**2 ) when gfs_physics_nml.override_surface_radiative_fluxes == .true.
@@ -3799,6 +3801,7 @@ end subroutine overrides_create
     allocate (Diag%totprcpb(IM))
     allocate (Diag%gflux   (IM))
     allocate (Diag%dlwsfc  (IM))
+    allocate (Diag%dswsfc  (IM))
     allocate (Diag%netflxsfc     (IM))
     allocate (Diag%qflux_restore (IM))
     allocate (Diag%MLD     (IM))
@@ -3808,6 +3811,7 @@ end subroutine overrides_create
        allocate (Diag%el_myj (IM, Model%levs))
     endif
     allocate (Diag%ulwsfc  (IM))
+    allocate (Diag%uswsfc  (IM))
     if (Model%override_surface_radiative_fluxes) then
       allocate (Diag%dlwsfc_override(IM))
       allocate (Diag%dswsfc_override(IM))
@@ -4085,11 +4089,13 @@ end subroutine overrides_create
     Diag%dqsfc   = zero
     Diag%gflux   = zero
     Diag%dlwsfc  = zero
+    Diag%dswsfc  = zero
     Diag%netflxsfc     = zero
     Diag%qflux_restore = zero
     Diag%MLD     = zero
     Diag%tclim_iano    = zero
     Diag%ulwsfc  = zero
+    Diag%uswsfc  = zero
     Diag%suntim  = zero
     Diag%runoff  = zero
     Diag%ep      = zero

--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -1330,6 +1330,27 @@ module GFS_typedefs
       procedure :: phys_zero => diag_phys_zero
   end type GFS_diag_type
 
+!----------------------------------------------------------------
+! GFS_overrides_from_python_wrapper_type
+!  Container with variables used for overriding fields in the
+!  GFS_physics_driver from a Python-wrapped version of the model.
+!
+!  Currently the only supported variables for overriding are the
+!  downward longwave, downward shortwave, and net shortwave
+!  radiative fluxes at the surface seen by the land surface model.
+!  Memory will only be allocated for these variables, and they will
+!  only be used for overriding, if
+!  gfs_physics_nml.override_surface_radiative_fluxes is set to
+!  .true..
+!----------------------------------------------------------------
+  type GFS_overrides_from_python_wrapper_type
+    real (kind=kind_phys), pointer :: adjsfcdlw_override(:) => null()  !< override to the downward longwave radiation flux at the surface
+    real (kind=kind_phys), pointer :: adjsfcdsw_override(:) => null()  !< override to the downward shortwave radiation flux at the surface
+    real (kind=kind_phys), pointer :: adjsfcnsw_override(:) => null()  !< override to the net shortwave radiation flux at the surface
+    contains
+      procedure :: create  => overrides_from_python_wrapper_create  !<   allocate array data
+  end type GFS_overrides_from_python_wrapper_type
+
 !----------------
 ! PUBLIC ENTITIES
 !----------------
@@ -2016,6 +2037,23 @@ module GFS_typedefs
 
   end subroutine coupling_create
 
+subroutine overrides_from_python_wrapper_create(OverridesFromPythonWrapper, IM, Model)
+  implicit none
+
+  class(GFS_overrides_from_python_wrapper_type) :: OverridesFromPythonWrapper
+  integer,                 intent(in) :: IM
+  type(GFS_control_type),  intent(in) :: Model
+
+  if (Model%override_surface_radiative_fluxes) then
+    allocate(OverridesFromPythonWrapper%adjsfcdlw_override(IM))
+    allocate(OverridesFromPythonWrapper%adjsfcdsw_override(IM))
+    allocate(OverridesFromPythonWrapper%adjsfcnsw_override(IM))
+    OverridesFromPythonWrapper%adjsfcdlw_override = clear_val
+    OverridesFromPythonWrapper%adjsfcdsw_override = clear_val
+    OverridesFromPythonWrapper%adjsfcnsw_override = clear_val
+  endif
+
+end subroutine overrides_from_python_wrapper_create
 
 !----------------------
 ! GFS_control_type%init

--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -142,9 +142,6 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: sst (:)     => null()   !< sea surface temperature
     real (kind=kind_phys), pointer :: ci (:)      => null()   !< sea ice fraction
     integer, pointer :: nwat                      => null()  !< number of water species used in the model
-    real (kind=kind_phys), pointer :: adjsfcdlw_override(:) => null()  !< override to the downward longwave radiation flux at the surface
-    real (kind=kind_phys), pointer :: adjsfcdsw_override(:) => null()  !< override to the downward shortwave radiation flux at the surface
-    real (kind=kind_phys), pointer :: adjsfcnsw_override(:) => null()  !< override to the net shortwave radiation flux at the surface
     contains
       procedure :: create  => statein_create  !<   allocate array data
 
@@ -1468,15 +1465,6 @@ module GFS_typedefs
     Statein%smc   = clear_val
     Statein%stc   = clear_val
     Statein%slc   = clear_val
-
-    if (Model%override_surface_radiative_fluxes) then
-      allocate(Statein%adjsfcdlw_override(IM))
-      allocate(Statein%adjsfcdsw_override(IM))
-      allocate(Statein%adjsfcnsw_override(IM))
-      Statein%adjsfcdlw_override = clear_val
-      Statein%adjsfcdsw_override = clear_val
-      Statein%adjsfcnsw_override = clear_val
-    endif
 
   end subroutine statein_create
 

--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -1197,9 +1197,9 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: gflux  (:)    => null()   !< groud conductive heat flux
     real (kind=kind_phys), pointer :: dlwsfc (:)    => null()   !< time accumulated sfc dn lw flux ( w/m**2 )
     real (kind=kind_phys), pointer :: ulwsfc (:)    => null()   !< time accumulated sfc up lw flux ( w/m**2 )
+    real (kind=kind_phys), pointer :: dlwsfc_override (:) => null()   !< time accumulated sfc dn lw flux ( w/m**2 ) when gfs_physics_nml.override_surface_radiative_fluxes == .true.
     real (kind=kind_phys), pointer :: dswsfc_override (:) => null()   !< time accumulated sfc dn sw flux ( w/m**2 ) when gfs_physics_nml.override_surface_radiative_fluxes == .true.
     real (kind=kind_phys), pointer :: uswsfc_override (:) => null()   !< time accumulated sfc up sw flux ( w/m**2 ) when gfs_physics_nml.override_surface_radiative_fluxes == .true.
-    real (kind=kind_phys), pointer :: dlwsfc_override (:) => null()   !< time accumulated sfc dn lw flux ( w/m**2 ) when gfs_physics_nml.override_surface_radiative_fluxes == .true.
     real (kind=kind_phys), pointer :: suntim (:)    => null()   !< sunshine duration time (s)
     real (kind=kind_phys), pointer :: runoff (:)    => null()   !< total water runoff
     real (kind=kind_phys), pointer :: ep     (:)    => null()   !< potential evaporation

--- a/IPD_layer/IPD_driver.F90
+++ b/IPD_layer/IPD_driver.F90
@@ -52,8 +52,7 @@ module IPD_driver
     call initialize (IPD_Control, IPD_Data(:)%Statein, IPD_Data(:)%Stateout,      &
                      IPD_Data(:)%Sfcprop, IPD_Data(:)%Coupling, IPD_Data(:)%Grid, &
                      IPD_Data(:)%Tbd, IPD_Data(:)%Cldprop, IPD_Data(:)%Radtend,   &
-                     IPD_Data(:)%Intdiag, IPD_Data(:)%OverridesFromPythonWrapper, &
-                     IPD_init_parm)
+                     IPD_Data(:)%Intdiag, IPD_Data(:)%Overrides, IPD_init_parm)
 
 
     !--- populate/associate the Diag container elements
@@ -119,8 +118,7 @@ module IPD_driver
     call physics_step1 (IPD_control, IPD_Data%Statein, IPD_Data%Stateout,   &
                         IPD_Data%Sfcprop, IPD_Data%Coupling, IPD_Data%Grid, &
                         IPD_Data%Tbd, IPD_Data%Cldprop, IPD_Data%Radtend,   &
-                        IPD_Data%Intdiag,                                   &
-                        IPD_Data%OverridesFromPythonWrapper)
+                        IPD_Data%Intdiag, IPD_Data%Overrides)
 
   end subroutine IPD_physics_step1
 

--- a/IPD_layer/IPD_driver.F90
+++ b/IPD_layer/IPD_driver.F90
@@ -52,7 +52,8 @@ module IPD_driver
     call initialize (IPD_Control, IPD_Data(:)%Statein, IPD_Data(:)%Stateout,      &
                      IPD_Data(:)%Sfcprop, IPD_Data(:)%Coupling, IPD_Data(:)%Grid, &
                      IPD_Data(:)%Tbd, IPD_Data(:)%Cldprop, IPD_Data(:)%Radtend,   &
-                     IPD_Data(:)%Intdiag, IPD_init_parm)
+                     IPD_Data(:)%Intdiag, IPD_Data(:)%OverridesFromPythonWrapper, &
+                     IPD_init_parm)
 
 
     !--- populate/associate the Diag container elements
@@ -118,7 +119,8 @@ module IPD_driver
     call physics_step1 (IPD_control, IPD_Data%Statein, IPD_Data%Stateout,   &
                         IPD_Data%Sfcprop, IPD_Data%Coupling, IPD_Data%Grid, &
                         IPD_Data%Tbd, IPD_Data%Cldprop, IPD_Data%Radtend,   &
-                        IPD_Data%Intdiag)
+                        IPD_Data%Intdiag,                                   &
+                        IPD_Data%OverridesFromPythonWrapper)
 
   end subroutine IPD_physics_step1
 

--- a/IPD_layer/IPD_typedefs.F90
+++ b/IPD_layer/IPD_typedefs.F90
@@ -8,7 +8,7 @@ module IPD_typedefs
                                        grid_type,     tbd_type,          &
                                        cldprop_type,  radtend_type,      &
                                        intdiag_type,                     &
-                                       overrides_from_python_wrapper_type
+                                       overrides_type
 
 !--------------------
 !  IPD sub-containers
@@ -23,7 +23,7 @@ module IPD_typedefs
     type(cldprop_type)  :: Cldprop
     type(radtend_type)  :: Radtend
     type(intdiag_type)  :: Intdiag
-    type(overrides_from_python_wrapper_type) :: OverridesFromPythonWrapper
+    type(overrides_type) :: Overrides
   end type IPD_data_type
 
 

--- a/IPD_layer/IPD_typedefs.F90
+++ b/IPD_layer/IPD_typedefs.F90
@@ -7,7 +7,8 @@ module IPD_typedefs
                                        sfcprop_type,  coupling_type,     &
                                        grid_type,     tbd_type,          &
                                        cldprop_type,  radtend_type,      &
-                                       intdiag_type
+                                       intdiag_type,                     &
+                                       overrides_from_python_wrapper_type
 
 !--------------------
 !  IPD sub-containers
@@ -22,6 +23,7 @@ module IPD_typedefs
     type(cldprop_type)  :: Cldprop
     type(radtend_type)  :: Radtend
     type(intdiag_type)  :: Intdiag
+    type(overrides_from_python_wrapper_type) :: OverridesFromPythonWrapper
   end type IPD_data_type
 
 


### PR DESCRIPTION
**Description**

This PR adds hooks to enable overriding the surface radiative fluxes seen by the land and ocean models following https://github.com/ai2cm/fv3gfs-fortran/pull/158 in AI2's fork of FV3GFS.  [This document](https://paper.dropbox.com/doc/2021-03-12-design-of-the-fortran-hooks-for-overriding-the-surface-radiative-fluxes-seen-by-the-surface-schemes-o4oxKjCgRxbfjrXMrCj7c) contains a description of the thought process behind this code in FV3GFS, which has been used in several studies.  In short it:
- Adds fields to a new data structure (`IPD_Data%OverridesFromPythonWrapper`) that are meant to hold data for overriding the surface radiative fluxes (namely the downward longwave, downward shortwave, and net shortwave radiative components).
- Creates pointers in the physics driver for these fluxes, which are set to either point to the adjusted values from the radiative transfer code (i.e. how the model normally runs) or the overriding fluxes, depending on the value of the `gfs_physics_nml.override_surface_radiative_fluxes` namelist parameter.
- Configures the radiative flux diagnostics to reflect what the surface felt, and adds additional diagnostics for the radiative fluxes output by the radiative transfer code when they are being overridden (i.e. the `_from_rrtmg` fields).

Note that this PR also must be coupled with a PR to NOAA-GFDL/atmos_drivers to follow through with passing the `override_surface_radiative_fluxes` namelist parameter to the diagnostics initialization routine (see NOAA-GFDL/atmos_drivers#31).

@lharris4 this should be the last set of PRs needed to obtain feature parity with our wrapper of FV3GFS.  Since this does something science-related, I'm guessing it may require a more careful review.

**How Has This Been Tested?**

These changes have been tested in https://github.com/ai2cm/SHiELD-wrapper/pull/5.  There we test that overriding the fluxes changes the solution of the model, and that the diagnostics are updated as expected based on the overridden values.  As expected, the answers for the model also do not change in configurations where `gfs_physics_nml.override_surface_radiative_fluxes` is `.false.` (the default).

**Checklist:**
Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
