### PR TITLE
Make `gfdl_diag_type` and `Diag_diag_manager_controlled` in `FV3GFS_io.F90` public

### DIFF
--- a/FV3GFS/FV3GFS_io.F90
+++ b/FV3GFS/FV3GFS_io.F90
@@ -77,7 +77,7 @@ module FV3GFS_io_mod
   public  register_coarse_diag_manager_controlled_diagnostics
   public  send_diag_manager_controlled_diagnostic_data
   public  sfc_data_override
-  public  Diag
+  public  gfdl_diag_type, Diag, Diag_diag_manager_controlled
 
   !--- GFDL filenames
   character(len=32)  :: fn_oro = 'oro_data.nc'


### PR DESCRIPTION
**Description**

This is somewhat of a followup to #30.  In doing some more work I realized that it would also be useful if `gfdl_diag_type`  and `Diag_diag_manager_controlled` were made public in `FV3GFS_io.F90` as well.  @lharris4 and @bensonr let me know if this seems OK to you.

**How Has This Been Tested?**

I have tested a feature that depends on this in a Python wrapped version of SHiELD in https://github.com/ai2cm/SHiELD-wrapper/pull/18.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
