### PR TITLE
Fix prescribed Q-flux bug and improve user experience of SOM

### DIFF
--- a/FV3GFS/FV3GFS_io.F90
+++ b/FV3GFS/FV3GFS_io.F90
@@ -7018,7 +7018,7 @@ module FV3GFS_io_mod
     idx = idx + 1
     Diag(idx)%axes = 2
     Diag(idx)%name = 'MLD'
-    Diag(idx)%desc = 'ocean mixed layer depth'
+    Diag(idx)%desc = 'Interval-average ocean mixed layer depth'
     Diag(idx)%unit = 'm'
     Diag(idx)%mod_name = 'gfs_phys'
     Diag(idx)%cnvfac = cn_one
@@ -7027,6 +7027,30 @@ module FV3GFS_io_mod
     allocate (Diag(idx)%data(nblks))
     do nb = 1,nblks
       Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%mld(:)
+    enddo
+
+    idx = idx + 1
+    Diag(idx)%axes = 2
+    Diag(idx)%name = 'MLDI'
+    Diag(idx)%desc = 'Instantaneous ocean mixed layer depth'
+    Diag(idx)%unit = 'm'
+    Diag(idx)%mod_name = 'gfs_phys'
+    Diag(idx)%coarse_graining_method = AREA_WEIGHTED
+    allocate (Diag(idx)%data(nblks))
+    do nb = 1,nblks
+      Diag(idx)%data(nb)%var2 => Sfcprop(nb)%mld(:)
+    enddo
+
+    idx = idx + 1
+    Diag(idx)%axes = 2
+    Diag(idx)%name = 'prescribed_qflux'
+    Diag(idx)%desc = 'Instantaneous prescribed ocean Q-flux'
+    Diag(idx)%unit = 'W/m**2'
+    Diag(idx)%mod_name = 'gfs_phys'
+    Diag(idx)%coarse_graining_method = AREA_WEIGHTED
+    allocate (Diag(idx)%data(nblks))
+    do nb = 1,nblks
+      Diag(idx)%data(nb)%var2 => Sfcprop(nb)%qfluxadj(:)
     enddo
 
     idx = idx + 1

--- a/FV3GFS/FV3GFS_io.F90
+++ b/FV3GFS/FV3GFS_io.F90
@@ -7260,7 +7260,7 @@ module FV3GFS_io_mod
                   ii = i + isc - 1
                   nb = Atm_block%blkno(ii,jj)
                   ix = Atm_block%ixp(ii,jj)
-                  var2d(i,j) = Diag(index)%data(nb)%var2(ix)
+                  var2d(i,j) = Diag_diag_manager_controlled(index)%data(nb)%var2(ix)
               enddo
             enddo
           endif

--- a/FV3GFS/FV3GFS_io.F90
+++ b/FV3GFS/FV3GFS_io.F90
@@ -1647,6 +1647,38 @@ module FV3GFS_io_mod
 
   end subroutine sfc_prop_restart_read
 
+  subroutine compute_surface_type_fraction(Atm_block, isc, jsc, nx, ny, diagnostic, result)
+    type(block_control_type), intent(in) :: Atm_block
+    integer, intent(in) :: isc, jsc, nx, ny
+    type(gfdl_diag_type), intent(in) :: diagnostic
+    real, intent(out) :: result(nx, ny)
+
+    integer :: i, j, ii, jj, nb, ix, surface_type_code
+
+    select case(trim(diagnostic%name))
+      case ('ocean_fraction')
+        surface_type_code = 0
+      case ('land_fraction')
+        surface_type_code = 1
+      case ('sea_ice_fraction')
+        surface_type_code = 2
+    end select
+
+    do j = 1, ny
+      jj = j + jsc - 1
+      do i = 1, nx
+          ii = i + isc - 1
+          nb = Atm_block%blkno(ii,jj)
+          ix = Atm_block%ixp(ii,jj)
+          if (nint(diagnostic%data(nb)%var2(ix)) .eq. surface_type_code) then
+            result(i,j) = 1.0
+          else
+            result(i,j) = 0.0
+          endif
+      enddo
+    enddo
+  end subroutine compute_surface_type_fraction
+
   subroutine sfc_data_override(Time, IPD_data, Atm_block, Model)
 
     implicit none
@@ -2650,8 +2682,9 @@ module FV3GFS_io_mod
 
   end subroutine phys_restart_write
 
-  subroutine register_diag_manager_controlled_diagnostics(Time, IntDiag, nblks, axes)
+  subroutine register_diag_manager_controlled_diagnostics(Time, Sfcprop, IntDiag, nblks, axes)
     type(time_type), intent(in) :: Time
+    type(Gfs_sfcprop_type), intent(in) :: Sfcprop(:)
     type(GFS_diag_type), intent(in) :: IntDiag(:)
     integer, intent(in) :: nblks
     integer, intent(in) :: axes(4)
@@ -2994,6 +3027,66 @@ module FV3GFS_io_mod
     allocate (Diag_diag_manager_controlled(index)%data(nblks))
     do nb = 1,nblks
       Diag_diag_manager_controlled(index)%data(nb)%var2 => IntDiag(nb)%q_dt_int(:,5)
+   enddo
+
+   index = index + 1
+   Diag_diag_manager_controlled(index)%axes = 2
+   Diag_diag_manager_controlled(index)%name = 'ocean_fraction'
+   Diag_diag_manager_controlled(index)%desc = 'fraction of grid cell classified as ocean type'
+   Diag_diag_manager_controlled(index)%unit = 'fraction'
+   Diag_diag_manager_controlled(index)%mod_name = 'gfs_sfc'
+   Diag_diag_manager_controlled(index)%coarse_graining_method = 'area_weighted'
+   allocate (Diag_diag_manager_controlled(index)%data(nblks))
+   do nb = 1,nblks
+     Diag_diag_manager_controlled(index)%data(nb)%var2 => Sfcprop(nb)%slmsk(:)
+   enddo
+
+   index = index + 1
+   Diag_diag_manager_controlled(index)%axes = 2
+   Diag_diag_manager_controlled(index)%name = 'land_fraction'
+   Diag_diag_manager_controlled(index)%desc = 'fraction of grid cell classified as land type'
+   Diag_diag_manager_controlled(index)%unit = 'fraction'
+   Diag_diag_manager_controlled(index)%mod_name = 'gfs_sfc'
+   Diag_diag_manager_controlled(index)%coarse_graining_method = 'area_weighted'
+   allocate (Diag_diag_manager_controlled(index)%data(nblks))
+   do nb = 1,nblks
+     Diag_diag_manager_controlled(index)%data(nb)%var2 => Sfcprop(nb)%slmsk(:)
+   enddo
+
+   index = index + 1
+   Diag_diag_manager_controlled(index)%axes = 2
+   Diag_diag_manager_controlled(index)%name = 'sea_ice_fraction'
+   Diag_diag_manager_controlled(index)%desc = 'fraction of grid cell classified as sea ice type'
+   Diag_diag_manager_controlled(index)%unit = 'fraction'
+   Diag_diag_manager_controlled(index)%mod_name = 'gfs_sfc'
+   Diag_diag_manager_controlled(index)%coarse_graining_method = 'area_weighted'
+   allocate (Diag_diag_manager_controlled(index)%data(nblks))
+   do nb = 1,nblks
+     Diag_diag_manager_controlled(index)%data(nb)%var2 => Sfcprop(nb)%slmsk(:)
+   enddo
+
+   index = index + 1
+   Diag_diag_manager_controlled(index)%axes = 2
+   Diag_diag_manager_controlled(index)%name = 'mixed_layer_depth'
+   Diag_diag_manager_controlled(index)%desc = 'ocean mixed layer depth'
+   Diag_diag_manager_controlled(index)%unit = 'm'
+   Diag_diag_manager_controlled(index)%mod_name = 'gfs_phys'
+   Diag_diag_manager_controlled(index)%coarse_graining_method = AREA_WEIGHTED
+   allocate (Diag_diag_manager_controlled(index)%data(nblks))
+   do nb = 1,nblks
+     Diag_diag_manager_controlled(index)%data(nb)%var2 => Sfcprop(nb)%mld(:)
+   enddo
+
+   index = index + 1
+   Diag_diag_manager_controlled(index)%axes = 2
+   Diag_diag_manager_controlled(index)%name = 'prescribed_qflux'
+   Diag_diag_manager_controlled(index)%desc = 'prescribed ocean Q-flux'
+   Diag_diag_manager_controlled(index)%unit = 'W/m**2'
+   Diag_diag_manager_controlled(index)%mod_name = 'gfs_phys'
+   Diag_diag_manager_controlled(index)%coarse_graining_method = AREA_WEIGHTED
+   allocate (Diag_diag_manager_controlled(index)%data(nblks))
+   do nb = 1,nblks
+     Diag_diag_manager_controlled(index)%data(nb)%var2 => Sfcprop(nb)%qfluxadj(:)
    enddo
 
    do index = 1, DIAG_SIZE
@@ -7031,30 +7124,6 @@ module FV3GFS_io_mod
 
     idx = idx + 1
     Diag(idx)%axes = 2
-    Diag(idx)%name = 'MLDI'
-    Diag(idx)%desc = 'Instantaneous ocean mixed layer depth'
-    Diag(idx)%unit = 'm'
-    Diag(idx)%mod_name = 'gfs_phys'
-    Diag(idx)%coarse_graining_method = AREA_WEIGHTED
-    allocate (Diag(idx)%data(nblks))
-    do nb = 1,nblks
-      Diag(idx)%data(nb)%var2 => Sfcprop(nb)%mld(:)
-    enddo
-
-    idx = idx + 1
-    Diag(idx)%axes = 2
-    Diag(idx)%name = 'prescribed_qflux'
-    Diag(idx)%desc = 'Instantaneous prescribed ocean Q-flux'
-    Diag(idx)%unit = 'W/m**2'
-    Diag(idx)%mod_name = 'gfs_phys'
-    Diag(idx)%coarse_graining_method = AREA_WEIGHTED
-    allocate (Diag(idx)%data(nblks))
-    do nb = 1,nblks
-      Diag(idx)%data(nb)%var2 => Sfcprop(nb)%qfluxadj(:)
-    enddo
-
-    idx = idx + 1
-    Diag(idx)%axes = 2
     Diag(idx)%name = 'ps_dt'
     Diag(idx)%desc = 'surface pressure tendency'
     Diag(idx)%unit = 'Pa/3hr'
@@ -7180,15 +7249,21 @@ module FV3GFS_io_mod
       if (trim(Diag_diag_manager_controlled(index)%name) .eq. '') exit
       if (Diag_diag_manager_controlled(index)%id .gt. 0 .or. Diag_diag_manager_controlled_coarse(index)%id .gt. 0) then
         if (Diag_diag_manager_controlled(index)%axes .eq. 2) then
-          do j = 1, ny
-            jj = j + jsc - 1
-            do i = 1, nx
-                ii = i + isc - 1
-                nb = Atm_block%blkno(ii,jj)
-                ix = Atm_block%ixp(ii,jj)
-                var2d(i,j) = Diag_diag_manager_controlled(index)%data(nb)%var2(ix)
+          if (trim(Diag_diag_manager_controlled(index)%name) .eq. 'ocean_fraction' .or. &
+              trim(Diag_diag_manager_controlled(index)%name) .eq. 'land_fraction' .or. &
+              trim(Diag_diag_manager_controlled(index)%name) .eq. 'sea_ice_fraction') then
+            call compute_surface_type_fraction(Atm_block, isc, jsc, nx, ny, Diag_diag_manager_controlled(index), var2d)
+          else
+            do j = 1, ny
+              jj = j + jsc - 1
+              do i = 1, nx
+                  ii = i + isc - 1
+                  nb = Atm_block%blkno(ii,jj)
+                  ix = Atm_block%ixp(ii,jj)
+                  var2d(i,j) = Diag(index)%data(nb)%var2(ix)
+              enddo
             enddo
-          enddo
+          endif
           if (Diag_diag_manager_controlled(index)%id > 0) then
             used = send_data(Diag_diag_manager_controlled(index)%id, var2d, Time)
           endif

--- a/gsmphys/sfcsub.F
+++ b/gsmphys/sfcsub.F
@@ -7528,7 +7528,7 @@ cjfe
      &,               imsk, jmsk, slmskh, gaus,blno, blto
      &,               outlat, outlon, me)
           if (me .eq. 0) write(6,*) 'climatological ocean 
-     &                           mixed layer depth read in.'
+     &                           Q-flux read in.'
 
         endif
 !
@@ -7808,7 +7808,7 @@ cjfe
      &,               imsk, jmsk, slmskh, gaus,blno, blto
      &,               outlat, outlon, me)
           if (me .eq. 0) write(6,*) 'climatological ocean 
-     &                           mixed layer depth read in.'
+     &                           Q-flux read in.'
 
         endif
 !
@@ -8008,6 +8008,12 @@ cjfe
       if(fnmldc(1:8).ne.'        ') then
         do i=1,len
          mldclm(i) = wei1m * mld(i,k1) + wei2m * mld(i,k2)
+        enddo
+      endif
+
+      if(fnqfluxc(1:8).ne.'        ') then
+        do i=1,len
+         qfluxadj(i) = wei1m * qflux(i,k1) + wei2m * qflux(i,k2)
         enddo
       endif
 !clu ----------------------------------------------------------------------

--- a/gsmphys/som_mlm.F90
+++ b/gsmphys/som_mlm.F90
@@ -133,7 +133,7 @@
 !      close (Model%nlunit)
 
 #ifdef INTERNAL_FILE_NML
-        read(input_nml_file, nml=ocean_nml, iostat=ios)
+        read(input_nml_file, nml=ocean_nml)
 #else
 !       print *,' in sfcsub nlunit=',nlunit,' me=',me,' ialb=',ialb
        inquire (file=trim(Model%fn_nml), exist=exists)


### PR DESCRIPTION
**Description** 

This PR fixes a bug in reading in a climatological Q-flux prescribed from a file, and adds a couple diagnostics to allow for easier inspection of the instantaneous values of the Q-flux and mixed layer depth prescribed.

Note I have included another minor change to the slab ocean model code, which removes the `iostat` argument from the namelist read call.  If `iostat` is included in this call and namelist parameters are mistyped, then the simulation will continue without reading the rest of the variables in the `ocean_nml` namelist, leading to difficult to debug / unexpected behavior.  With `iostat` removed—[as is done elsewhere in the code](https://github.com/NOAA-GFDL/SHiELD_physics/blob/d44f50f2cf0fab2b7919df84da5a419c01d55164/GFS_layer/GFS_typedefs.F90#L2528)—the model will immediately crash with an informative error message, making configuration typos less dangerous and easier to debug, e.g.:

```
At line 136 of file /SHiELD/SHiELD_SRC/SHiELD_physics/gsmphys/som_mlm.F90
Fortran runtime error: Cannot match namelist object name mld_restore_timescale
```

Fixes #34 

**How Has This Been Tested?**

I have tested this by running SHiELD with a Q-flux and mixed layer depth prescribed from files, and have plotted snapshots of the newly added diagnostics.  Results look as expected given the data I prescribed.

![2023-12-13-prescribed-qflux](https://github.com/NOAA-GFDL/SHiELD_physics/assets/6628425/6b95a04b-d101-4ea4-aab9-f558bf09bc96)

![2023-12-13-prescribed-mld](https://github.com/NOAA-GFDL/SHiELD_physics/assets/6628425/300ccee7-28af-482f-9e11-66086485b64d)

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
