### PR TITLE
Fix type of input argument in compute_surface_type_fraction

### DIFF
--- a/FV3GFS/FV3GFS_io.F90
+++ b/FV3GFS/FV3GFS_io.F90
@@ -1651,7 +1651,7 @@ module FV3GFS_io_mod
     type(block_control_type), intent(in) :: Atm_block
     integer, intent(in) :: isc, jsc, nx, ny
     type(gfdl_diag_type), intent(in) :: diagnostic
-    real, intent(out) :: result(nx, ny)
+    real(kind=kind_phys), intent(out) :: result(nx, ny)
 
     integer :: i, j, ii, jj, nb, ix, surface_type_code
 


### PR DESCRIPTION
**Description**

In the most recent updates from PRs #35 and #36, a new subroutine is declared `compute_surface_type_fraction`
When I try to compile SHiELD 32bit, I get a type mismatch error at line 7255:
https://github.com/NOAA-GFDL/SHiELD_physics/blob/23a9ec02086577aa621b26331478199c3cb40552/FV3GFS/FV3GFS_io.F90#L7255
related to `var2d`

`var2d` is of `real(kind=kind_phys)`.  I believe that the type of the matching argument in `compute_surface_type_fraction` should also be the same.

Fixes # (issue)

**How Has This Been Tested?**

tested with a build on Gaea.  Currently testing with regression tests.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
