### PR TITLE
Permit running with a global slab ocean and disabling radiation quasi-sea-ice

### DIFF
--- a/GFS_layer/GFS_driver.F90
+++ b/GFS_layer/GFS_driver.F90
@@ -206,7 +206,8 @@ module GFS_driver
     si = (Init_parm%ak + Init_parm%bk * p_ref - Init_parm%ak(Model%levr+1)) &
              / (p_ref - Init_parm%ak(Model%levr+1))
     call rad_initialize (si, Model%levr, Model%ictm, Model%isol, &
-           Model%ico2, Model%iaer, Model%ialb, Model%iems,       &
+           Model%ico2, Model%iaer, Model%ialb,                   &
+           Model%disable_radiation_quasi_sea_ice, Model%iems,    &
            Model%ntcw, Model%num_p2d,  Model%num_p3d,            &
            Model%npdf3d, Model%ntoz,                             &
            Model%iovr_sw, Model%iovr_lw, Model%isubc_sw,         &

--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -516,6 +516,13 @@ module GFS_typedefs
     integer              :: ico2            !< prescribed global mean value (old opernl)
     integer              :: ialb            !< use climatology alb, based on sfc type
                                             !< 1 => use modis based alb
+
+    logical              :: disable_radiation_quasi_sea_ice
+                                            !< flag to disable
+                                            !< radiation code treating ocean grid
+                                            !< cells with temperature below
+                                            !< freezing as sea ice
+    
     integer              :: iems            !< use fixed value of 1.0
     integer              :: iaer            !< default aerosol effect in sw only
     integer              :: iovr_sw         !< sw: max-random overlap clouds
@@ -2137,6 +2144,13 @@ end subroutine overrides_create
     integer              :: ico2           =  0              !< prescribed global mean value (old opernl)
     integer              :: ialb           =  0              !< use climatology alb, based on sfc type
                                                              !< 1 => use modis based alb
+
+    logical              :: disable_radiation_quasi_sea_ice = .false.
+                                                             !< flag to disable
+                                                             !< radiation code treating ocean grid
+                                                             !< cells with temperature below
+                                                             !< freezing as sea ice
+
     integer              :: iems           =  0              !< use fixed value of 1.0
     integer              :: iaer           =  1              !< default aerosol effect in sw only
     integer              :: iovr_sw        =  1              !< sw: max-random overlap clouds
@@ -2452,6 +2466,7 @@ end subroutine overrides_create
                                cplflx, cplwav, lsidea,                                      &
                           !--- radiation parameters
                                fhswr, fhlwr, levr, nfxr, aero_in, iflip, isol, ico2, ialb,  &
+                               disable_radiation_quasi_sea_ice,                             &
                                isot, iems,  iaer, iovr_sw, iovr_lw, ictm, isubc_sw,         &
                                isubc_lw, crick_proof, ccnorm, lwhtr, swhtr, nkld,           &
                                fixed_date, fixed_solhr, fixed_sollat, daily_mean, sollat,   &
@@ -2615,6 +2630,7 @@ end subroutine overrides_create
     Model%isol             = isol
     Model%ico2             = ico2
     Model%ialb             = ialb
+    Model%disable_radiation_quasi_sea_ice = disable_radiation_quasi_sea_ice
     Model%iems             = iems
     Model%iaer             = iaer
     Model%iovr_sw          = iovr_sw
@@ -3310,6 +3326,7 @@ end subroutine overrides_create
       print *, ' isol              : ', Model%isol
       print *, ' ico2              : ', Model%ico2
       print *, ' ialb              : ', Model%ialb
+      print *, ' disable_radiation_quasi_sea_ice: ', Model%disable_radiation_quasi_sea_ice
       print *, ' iems              : ', Model%iems
       print *, ' iaer              : ', Model%iaer
       print *, ' iovr_sw           : ', Model%iovr_sw

--- a/gsmphys/physparam.f
+++ b/gsmphys/physparam.f
@@ -270,7 +270,10 @@
 !> surface albedo scheme control flag
 !!\n =0:vegetation type based climatological albedo scheme
 !!\n =1:seasonal albedo derived from MODIS measurements
-      integer, save :: ialbflg = 0      
+      integer, save :: ialbflg = 0
+!> flag to disable radiation code treating ocean grid cells with
+!!\n temperature below freezing as sea ice
+      logical, save :: ldisable_radiation_quasi_sea_ice = .false.
 !> surface emissivity scheme control flag
 !!\n =0:black-body surface emissivity(=1.0)
 !!\n =1:vegetation type based climatology emissivity(<1.0)

--- a/gsmphys/rad_initialize.f
+++ b/gsmphys/rad_initialize.f
@@ -2,7 +2,8 @@
       subroutine rad_initialize                                         &
 !...................................
 !  ---  inputs:
-     &     ( si,levr,ictm,isol,ico2,iaer,ialb,iems,ntcw, num_p2d,       &
+     &     ( si,levr,ictm,isol,ico2,iaer,ialb,                          &
+     &       disable_radiation_quasi_sea_ice,iems,ntcw, num_p2d,        &
      &       num_p3d,npdf3d,ntoz,iovr_sw,iovr_lw,isubc_sw,isubc_lw,     &
      &       crick_proof,ccnorm,norad_precip,                           &
      &       idate,iflip,me )
@@ -107,7 +108,7 @@
      &             iaermdl, laswflg, lalwflg, lavoflg, icldflg, icmphys,&
      &             iovrsw , iovrlw , lcrick , lcnorm , lnoprec,         &
      &             ialbflg, iemsflg, isubcsw, isubclw, ivflip , ipsd0,  &
-     &             kind_phys
+     &             kind_phys, ldisable_radiation_quasi_sea_ice
 
       use module_radiation_driver, only : radinit
 !
@@ -120,8 +121,8 @@
 
       real (kind=kind_phys), intent(in) :: si(levr+1)
 
-      logical, intent(in) :: crick_proof, ccnorm, norad_precip
-
+      logical, intent(in) :: crick_proof, ccnorm, norad_precip,         &
+     &                       disable_radiation_quasi_sea_ice
 !  ---  output: ( none )
 
 !  ---  local:
@@ -184,6 +185,7 @@
       isubclw = isubc_lw                ! sub-column cloud approx flag in lw radiation
 
       ialbflg= ialb                     ! surface albedo control flag
+      ldisable_radiation_quasi_sea_ice = disable_radiation_quasi_sea_ice  ! flag to disable treating below freezing ocean grid cells as sea ice
       iemsflg= iems                     ! surface emissivity control flag
 
       ivflip = iflip                    ! vertical index direction control flag
@@ -198,7 +200,10 @@
         print *,'  In rad_initialize, before calling radinit'
         print *,' si =',si
         print *,' levr=',levr,' ictm=',ictm,' isol=',isol,' ico2=',ico2,&
-     &          ' iaer=',iaer,' ialb=',ialb,' iems=',iems,' ntcw=',ntcw
+     &   ' iaer=',iaer,' ialb=',ialb,                                   &
+     &   ' disable_radiation_quasi_sea_ice=',                           & 
+     &   disable_radiation_quasi_sea_ice,                               &
+     &   ' iems=',iems,' ntcw=',ntcw
         print *,' np3d=',num_p3d,' ntoz=',ntoz,' iovr_sw=',iovr_sw,     &
      &          ' iovr_lw=',iovr_lw,' isubc_sw=',isubc_sw,              &
      &          ' isubc_lw=',isubc_lw,' iflip=',iflip,'  me=',me

--- a/gsmphys/som_mlm.F90
+++ b/gsmphys/som_mlm.F90
@@ -77,7 +77,8 @@
                                                               ! climatological SST plus initial anomaly
       logical               :: use_tvar_restore_sst  = .false.! using time varying restoring time scale for sst
       logical               :: use_tvar_restore_mld  = .false.! using time varying restoring time scale for mld
-      real(kind=kind_phys)  :: maxlat = 60.                   ! maximum latitudinal extent of the SOM/MLM; for most physical results, set <= 60.0
+      real(kind=kind_phys)  :: maxlat = 60.                   ! maximum latitudinal extent of the SOM/MLM; generally set to be <= 60, though
+                                                              ! can be useful to set to 90 in some circumstances
 
       namelist /ocean_nml/   &
        ocean_option, mld_option, mld_obs_ratio, stress_ratio, restore_method,  &

--- a/gsmphys/som_mlm.F90
+++ b/gsmphys/som_mlm.F90
@@ -35,9 +35,8 @@
 
       public  ocean_init, update_ocean
 !
-      real (kind=kind_phys)   :: maxlat, width_buffer, minmld,  &
+      real (kind=kind_phys)   :: width_buffer, minmld,  &
                                  cpwater, rhowater, omega, grav
-      parameter(maxlat       = 60.)  ! determine the maximum latitude band for SOM/MLM
       parameter(minmld       = 10.)  ! minimum mixed layer depth
       parameter(width_buffer = 15.)  ! the width of a buffer band where SST is determined by both SOM/MLM
                                      ! and climatology (or climatology plus initial anomaly)
@@ -66,8 +65,8 @@
       real(kind=kind_phys)  :: eps_day            = 10.       ! damping time scale of ocean current (days)
       real(kind=kind_phys)  :: sst_restore_tscale = 3.        ! restoring time scale for sst (day)
       real(kind=kind_phys)  :: mld_restore_tscale = 1.        ! restoring time scale for mld (day)
-      real(kind=kind_phys)  :: start_lat          = -30.      ! latitude starting from? Note that this value should not be smaller than -60.
-      real(kind=kind_phys)  :: end_lat            = 30.       ! latitude ending with? Note that this value should not be bigger than 60.
+      real(kind=kind_phys)  :: start_lat          = -30.      ! latitude starting from? Note that this value should not be smaller than -maxlat.
+      real(kind=kind_phys)  :: end_lat            = 30.       ! latitude ending with? Note that this value should not be bigger than maxlat.
       real(kind=kind_phys)  :: tday1              = 3.        !
       real(kind=kind_phys)  :: tday2              = 10.       !
       real(kind=kind_phys)  :: sst_restore_tscale1= 3.        ! restoring time scale for sst during the period from 1 to tday1
@@ -78,13 +77,14 @@
                                                               ! climatological SST plus initial anomaly
       logical               :: use_tvar_restore_sst  = .false.! using time varying restoring time scale for sst
       logical               :: use_tvar_restore_mld  = .false.! using time varying restoring time scale for mld
+      real(kind=kind_phys)  :: maxlat = 60.                   ! maximum latitudinal extent of the SOM/MLM; for most physical results, set <= 60.0
 
       namelist /ocean_nml/   &
        ocean_option, mld_option, mld_obs_ratio, stress_ratio, restore_method,  &
        use_old_mlm, use_rain_flux, use_qflux, do_mld_restore, const_mld, Gam,  &
        eps_day, sst_restore_tscale, mld_restore_tscale, start_lat, end_lat,    &
        tday1, tday2, sst_restore_tscale1, sst_restore_tscale2, mld_restore_tscale1, &
-       mld_restore_tscale2, use_tvar_restore_sst, use_tvar_restore_mld
+       mld_restore_tscale2, use_tvar_restore_sst, use_tvar_restore_mld, maxlat
 
 ! =================
       contains
@@ -149,11 +149,11 @@
 #endif
 
       if (start_lat < -maxlat) then
-       write(*,*) 'start_lat should not be smaller than -60.'
+       write(*,*) 'start_lat should not be smaller than', -maxlat
        call abort
       endif
       if (end_lat > maxlat) then
-       write(*,*) 'end_lat should not be larger than 60.'
+       write(*,*) 'end_lat should not be larger than', maxlat
        call abort
       endif
 


### PR DESCRIPTION
**Description**

This PR introduces two changes to facilitate running SHiELD with a global slab ocean:
- It adds a `ocean_nml.maxlat` namelist parameter to allow one to relax the current rigid constraint that the ocean model be limited to at most 60°S to 60°N.  To allow running with a global ocean, one must set this to `90.0`.  
- It adds a `gfs_physics_nml.disable_radiation_quasi_sea_ice` namelist parameter to allow one to disable the existing default code in that radiation scheme that treats below freezing ocean grid cells as having a surface albedo and emissivity of sea-ice rather than open water.  Since SHiELD does not have a true interactive sea-ice model, this code is only partly physical and generally makes sense to disable in global slab ocean simulations to avoid an extreme ice-albedo feedback.  

The defaults of both of these namelist parameters have been set for backwards compatibility—in other words these code changes do not change answers by default.  

**How Has This Been Tested?**

- These code changes have been tested by running simulations with appropriate diagnostics to validate that the slab ocean is indeed active globally when `ocean_nml.maxlat` is set to `90.0`, and that the ocean surface albedo in below freezing regions is set as if it were open water rather than sea-ice when `gfs_physics_nml.disable_radiation_quasi_sea_ice` is set to `.true.`. 

![2024-02-06-disable-quasi-sea-ice-albedo-January](https://github.com/NOAA-GFDL/SHiELD_physics/assets/6628425/848fdf4b-46e4-49a0-abcc-b69170aace6f)

- Over other surface types the albedo appears unchanged modulo weather variability.  

![2024-02-06-disable-quasi-sea-ice-albedo-difference-January](https://github.com/NOAA-GFDL/SHiELD_physics/assets/6628425/a7595612-6330-4353-93dc-637319d7996e)

- I have also tested that the model produces bitwise identical results before and after adding the `disable_radiation_quasi_sea_ice` flag, with the flag set to its default `.false.`.

cc: @lharris4

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
