### PR TITLE
Selective port of land-ice-related updates from NCAR/ccpp-physics

### DIFF
--- a/GFS_layer/GFS_physics_driver.F90
+++ b/GFS_layer/GFS_physics_driver.F90
@@ -1321,6 +1321,7 @@ module module_physics_driver
             Model%iopt_run,   Model%iopt_sfc,  Model%iopt_frz,         &
             Model%iopt_inf,   Model%iopt_rad,  Model%iopt_alb,         &
             Model%iopt_snf,   Model%iopt_tbot, Model%iopt_stc,         &
+            Model%iopt_gla,                                            &
             grid%xlat, xcosz, Model%yearlen,   Model%julian, Model%imn,&
             Sfcprop%drainncprv, Sfcprop%draincprv, Sfcprop%dsnowprv,   &
             Sfcprop%dgraupelprv, Sfcprop%diceprv,                      &

--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -609,6 +609,7 @@ module GFS_typedefs
     integer              :: iopt_snf  !rainfall & snowfall (1-jordan91; 2->bats; 3->noah)
     integer              :: iopt_tbot !lower boundary of soil temperature (1->zero-flux; 2->noah)
     integer              :: iopt_stc  !snow/soil temperature time scheme (only layer 1)
+    integer              :: iopt_gla  !glacier option (1->phase change; 2->simple)
 
     !--- tuning parameters for physical parameterizations
     logical              :: ras             !< flag for ras convection scheme
@@ -2228,6 +2229,7 @@ end subroutine overrides_create
     integer              :: iopt_snf       =  1  !rainfall & snowfall (1-jordan91; 2->bats; 3->noah)
     integer              :: iopt_tbot      =  2  !lower boundary of soil temperature (1->zero-flux; 2->noah)
     integer              :: iopt_stc       =  1  !snow/soil temperature time scheme (only layer 1)
+    integer              :: iopt_gla       =  2  !glacier option (1->phase change; 2->simple)
 
     !--- tuning parameters for physical parameterizations
     logical              :: ras            = .false.                  !< flag for ras convection scheme
@@ -2479,6 +2481,7 @@ end subroutine overrides_create
                           !    Noah MP options
                                iopt_dveg,iopt_crs,iopt_btr,iopt_run,iopt_sfc, iopt_frz,     &
                                iopt_inf, iopt_rad,iopt_alb,iopt_snf,iopt_tbot,iopt_stc,     &
+                               iopt_gla,                                                    &
                           !--- physical parameterizations
                                ras, trans_trac, old_monin, cnvgwd, mstrat, moist_adj,       &
                                cscnv, cal_pre, do_aw, do_shoc, shocaftcnv, shoc_cld,        &
@@ -2692,6 +2695,7 @@ end subroutine overrides_create
     Model%iopt_snf         = iopt_snf
     Model%iopt_tbot        = iopt_tbot
     Model%iopt_stc         = iopt_stc
+    Model%iopt_gla         = iopt_gla
 
 
     !--- tuning parameters for physical parameterizations
@@ -3070,6 +3074,7 @@ end subroutine overrides_create
         print *,'iopt_snf   =  ', Model%iopt_snf
         print *,'iopt_tbot   =  ',Model%iopt_tbot
         print *,'iopt_stc   =  ', Model%iopt_stc
+        print *,'iopt_gla   =  ', Model%iopt_gla
 
 
 
@@ -3389,6 +3394,7 @@ end subroutine overrides_create
       print *, ' iopt_snf          : ', Model%iopt_snf
       print *, ' iopt_tbot         : ', Model%iopt_tbot
       print *, ' iopt_stc          : ', Model%iopt_stc
+      print *, ' iopt_gla          : ', Model%iopt_gla
 
       endif
 

--- a/gsmphys/module_sf_noahmp_glacier.f90
+++ b/gsmphys/module_sf_noahmp_glacier.f90
@@ -2329,8 +2329,10 @@ end if   ! opt_gla == 1
 
    if(isnow /= 0) then
        sneqv = 0.
+       snowh = 0.
        do iz = isnow+1,0
              sneqv = sneqv + snice(iz) + snliq(iz)
+             snowh = snowh + dzsnso(iz)
        enddo
    end if
 

--- a/gsmphys/module_sf_noahmp_glacier.f90
+++ b/gsmphys/module_sf_noahmp_glacier.f90
@@ -2317,9 +2317,9 @@ end if   ! opt_gla == 1
 
 !to obtain equilibrium state of snow in glacier region
        
-   if(sneqv > 2000.) then   ! 2000 mm -> maximum water depth
+   if(sneqv > 100.) then   ! 100 mm -> maximum water depth
       bdsnow      = snice(0) / dzsnso(0)
-      snoflow     = (sneqv - 2000.)
+      snoflow     = (sneqv - 100.)
       snice(0)    = snice(0)  - snoflow 
       dzsnso(0)   = dzsnso(0) - snoflow/bdsnow
       snoflow     = snoflow / dt

--- a/gsmphys/module_sf_noahmp_glacier.f90
+++ b/gsmphys/module_sf_noahmp_glacier.f90
@@ -2512,6 +2512,7 @@ end if   ! opt_gla == 1
            ! the change in dz due to compaction
 
            dzsnso(j) = dzsnso(j)*(1.+pdzdtc)
+           dzsnso(j) = min(max(dzsnso(j),(snliq(j)+snice(j))/500.0),(snliq(j)+snice(j))/50.0)  ! limit adjustment to a reasonable density
         end if
 
         ! pressure of overlying snow

--- a/gsmphys/module_sf_noahmp_glacier.f90
+++ b/gsmphys/module_sf_noahmp_glacier.f90
@@ -700,10 +700,10 @@ contains
 ! thermal conductivity of snow
 
   do iz = isnow+1, 0
-     tksno(iz) = 3.2217e-6*bdsnoi(iz)**2.           ! stieglitz(yen,1965)
+!    tksno(iz) = 3.2217e-6*bdsnoi(iz)**2.           ! stieglitz(yen,1965)
 !    tksno(iz) = 2e-2+2.5e-6*bdsnoi(iz)*bdsnoi(iz)   ! anderson, 1976
 !    tksno(iz) = 0.35                                ! constant
-!    tksno(iz) = 2.576e-6*bdsnoi(iz)**2. + 0.074    ! verseghy (1991)
+     tksno(iz) = 2.576e-6*bdsnoi(iz)**2. + 0.074    ! verseghy (1991)
 !    tksno(iz) = 2.22*(bdsnoi(iz)/1000.)**1.88      ! douvill(yen, 1981)
   enddo
 

--- a/gsmphys/module_sf_noahmp_glacier.f90
+++ b/gsmphys/module_sf_noahmp_glacier.f90
@@ -2450,7 +2450,7 @@ end if   ! opt_gla == 1
    real (kind=kind_phys), parameter     :: c4 = 0.04     ![1/k]
    real (kind=kind_phys), parameter     :: c5 = 2.0      !
    real (kind=kind_phys), parameter     :: dm = 100.0    !upper limit on destructive metamorphism compaction [kg/m3]
-   real (kind=kind_phys), parameter     :: eta0 = 0.8e+6 !viscosity coefficient [kg-s/m2] 
+   real (kind=kind_phys), parameter     :: eta0 = 1.8e+6 !viscosity coefficient [kg-s/m2] 
                                         !according to anderson, it is between 0.52e6~1.38e6
    real (kind=kind_phys) :: burden !pressure of overlying snow [kg/m2]
    real (kind=kind_phys) :: ddz1   !rate of settling of snow pack due to destructive metamorphism.

--- a/gsmphys/module_sf_noahmp_glacier.f90
+++ b/gsmphys/module_sf_noahmp_glacier.f90
@@ -2274,6 +2274,7 @@ end if   ! opt_gla == 1
 ! local
   integer :: iz
   real (kind=kind_phys)    :: bdsnow  !bulk density of snow (kg/m3)
+  real (kind=kind_phys),parameter :: mwd  = 100.   !< maximum water depth (mm)
 ! ----------------------------------------------------------------------
    snoflow = 0.0
    ponding1 = 0.0
@@ -2317,9 +2318,9 @@ end if   ! opt_gla == 1
 
 !to obtain equilibrium state of snow in glacier region
        
-   if(sneqv > 100.) then   ! 100 mm -> maximum water depth
+   if(sneqv > mwd .and. isnow /= 0) then   ! 100 mm -> maximum water depth
       bdsnow      = snice(0) / dzsnso(0)
-      snoflow     = (sneqv - 100.)
+      snoflow     = (sneqv - mwd)
       snice(0)    = snice(0)  - snoflow 
       dzsnso(0)   = dzsnso(0) - snoflow/bdsnow
       snoflow     = snoflow / dt

--- a/gsmphys/module_sf_noahmplsm.f90
+++ b/gsmphys/module_sf_noahmplsm.f90
@@ -5912,8 +5912,10 @@ contains
 
    if(isnow < 0) then  ! mb: only do for multi-layer
        sneqv = 0.
+       snowh = 0.
        do iz = isnow+1,0
              sneqv = sneqv + snice(iz) + snliq(iz)
+             snowh = snowh + dzsnso(iz)
        enddo
    end if
 

--- a/gsmphys/module_sf_noahmplsm.f90
+++ b/gsmphys/module_sf_noahmplsm.f90
@@ -6412,7 +6412,7 @@ contains
    real (kind=kind_phys), parameter     :: c4 = 0.04     ![1/k]
    real (kind=kind_phys), parameter     :: c5 = 2.0      !
    real (kind=kind_phys), parameter     :: dm = 100.0    !upper limit on destructive metamorphism compaction [kg/m3]
-   real (kind=kind_phys), parameter     :: eta0 = 0.8e+6 !viscosity coefficient [kg-s/m2] 
+   real (kind=kind_phys), parameter     :: eta0 = 1.8e+6 !viscosity coefficient [kg-s/m2] 
                                         !according to anderson, it is between 0.52e6~1.38e6
    real (kind=kind_phys) :: burden !pressure of overlying snow [kg/m2]
    real (kind=kind_phys) :: ddz1   !rate of settling of snow pack due to destructive metamorphism.

--- a/gsmphys/module_sf_noahmplsm.f90
+++ b/gsmphys/module_sf_noahmplsm.f90
@@ -6474,6 +6474,7 @@ contains
            ! the change in dz due to compaction
 
            dzsnso(j) = dzsnso(j)*(1.+pdzdtc)
+           dzsnso(j) = min(max(dzsnso(j),(snliq(j)+snice(j))/500.0),(snliq(j)+snice(j))/50.0)  ! limit adjustment to a reasonable density
         end if
 
         ! pressure of overlying snow
@@ -6629,6 +6630,10 @@ contains
          snliq(j) = snliq(j) - qout
          qin = qout
       end if
+   end do
+
+   do j = isnow+1, 0
+     dzsnso(j) = min(max(dzsnso(j),(snliq(j)+snice(j))/500.0),(snliq(j)+snice(j))/50.0)  ! limit adjustment to a reasonable density
    end do
 
 ! liquid water from snow bottom to soil

--- a/gsmphys/module_sf_noahmplsm.f90
+++ b/gsmphys/module_sf_noahmplsm.f90
@@ -2119,10 +2119,10 @@ contains
 ! thermal conductivity of snow
 
   do iz = isnow+1, 0
-     tksno(iz) = 3.2217e-6*bdsnoi(iz)**2.           ! stieglitz(yen,1965)
+!    tksno(iz) = 3.2217e-6*bdsnoi(iz)**2.           ! stieglitz(yen,1965)
 !    tksno(iz) = 2e-2+2.5e-6*bdsnoi(iz)*bdsnoi(iz)   ! anderson, 1976
 !    tksno(iz) = 0.35                                ! constant
-!    tksno(iz) = 2.576e-6*bdsnoi(iz)**2. + 0.074    ! verseghy (1991)
+     tksno(iz) = 2.576e-6*bdsnoi(iz)**2. + 0.074    ! verseghy (1991)
 !    tksno(iz) = 2.22*(bdsnoi(iz)/1000.)**1.88      ! douvill(yen, 1981)
   enddo
 

--- a/gsmphys/sfc_noahmp_drv.f
+++ b/gsmphys/sfc_noahmp_drv.f
@@ -9,6 +9,7 @@
      &       shdmin, shdmax, snoalb, sfalb, flag_iter, flag_guess,      &
      &       idveg,iopt_crs, iopt_btr, iopt_run, iopt_sfc, iopt_frz,    &
      &       iopt_inf,iopt_rad, iopt_alb, iopt_snf,iopt_tbot,iopt_stc,  &
+     &       iopt_gla,                                                  &
      &       xlatin,xcoszin, iyrlen, julian,imon,                       &
      &       rainn_mp,rainc_mp,snow_mp,graupel_mp,ice_mp,               &
 
@@ -97,7 +98,8 @@
 
       integer,  intent(in) ::  idveg, iopt_crs,iopt_btr,iopt_run,       &
      &                         iopt_sfc,iopt_frz,iopt_inf,iopt_rad,     &
-     &                         iopt_alb,iopt_snf,iopt_tbot,iopt_stc
+     &                         iopt_alb,iopt_snf,iopt_tbot,iopt_stc,    &
+     &                         iopt_gla
 
       real (kind=kind_phys),  intent(in) :: julian
       integer,  intent(in)               :: iyrlen
@@ -142,6 +144,7 @@
      &    albdnir,  albivis,  albinir
 
 !  ---  locals:
+
       real (kind=kind_phys), dimension(im) :: rch, rho,                 &
      &       q0, qs1, theta1, tv1,  weasd_old, snwdph_old,              &
      &       tprcp_old, srflag_old, tskin_old, canopy_old
@@ -586,7 +589,8 @@
 
          call noahmp_options_glacier                                    &
      &   (idveg  ,iopt_crs  ,iopt_btr, iopt_run ,iopt_sfc ,iopt_frz,    &
-     &   iopt_inf ,iopt_rad ,iopt_alb ,iopt_snf ,iopt_tbot, iopt_stc )
+     &   iopt_inf ,iopt_rad ,iopt_alb ,iopt_snf ,iopt_tbot, iopt_stc,   &
+     &   iopt_gla)
 
        call noahmp_glacier (                                            &
      &             i       ,1       ,cosz    ,nsnow   ,nsoil   ,delt  , & ! in : time/space/model-related


### PR DESCRIPTION
**Description**

This PR ports a selected set of updates to the land-ice portions of Noah-MP (primarily `module_sf_noahmp_glacier.f90`) from [NCAR/ccpp-physics](https://github.com/NCAR/ccpp-physics).  

#### Primary change

The primary goal of this PR is accomplished by the first commit, which adds an `gfs_physics_nml.iopt_gla` namelist option to the version of Noah-MP implemented in SHiELD.  This new namelist option can be set to either `iopt_gla = 1` or `iopt_gla = 2`, with `iopt_gla = 1` resulting in the existing behavior, ostensibly allowing phase changes to occur within land ice, and `iopt_gla = 2` disabling phase changes within land ice.  

`iopt_gla = 2` has been set to be the new default for two reasons:

- It fixes the issue with `iopt_gla = 1` that the soil temperature in land ice regions would never fall below 273.16 K.
- It is hard-coded to be the behavior in NCAR/ccpp-physics.

#### Other changes

After the first commit, this PR includes some updates to the glacier physics and primary Noah-MP modules that appear genuinely related to land ice, as opposed to related to changes needed to refactor the handling of the surface layer to accommodate [GSL's MYNN scheme](https://sites.gsl.noaa.gov/articles/2014).  These changes were selected by manually inspecting the [commit history of the `module_sf_noahmp_glacier.F90` file in NCAR/ccpp-physics](https://github.com/NCAR/ccpp-physics/commits/main/physics/SFC_Models/Land/Noahmp/module_sf_noahmp_glacier.F90) one commit-diff at a time[^1].

[^1]: This is across file renames dating back to anything after [this commit](https://github.com/NCAR/ccpp-physics/commit/8b0179bd98cf9f0362e20c30fcdd847afbf1490a), which I believe is around the time that Kai last updated Noah-MP in SHiELD.  

Presumably these are bug fixes / tuning adjustments, so it seems sensible to make these changes at the same time as adding the `iopt_gla` option, but they are not essential for fixing the soil temperature issue over Antarctica.

**How Has This Been Tested?**

These changes have been tested by running short SHiELD simulations with Noah-MP and checking the soil temperature in Antarctica:

- With the existing code, as we have observed, the soil temperature is pinned to 273.16 K.
- With the first commit alone, and `iopt_gla = 2`, the soil temperature has a more realistic distribution in Antarctica, dropping to as low as around 200 K in the center.  With `iopt_gla = 1`, results are bitwise-identical to the existing code.
- With the addition of the updates in subsequent commits, results change for both the `iopt_gla = 1` and `iopt_gla = 2` options, but this is expected given that these are presumably bug fixes / tuning adjustments.

I will run longer C24 simulations to confirm details of the approximate changes in surface temperature we might expect as a result of this changes—based on earlier results I expect decreases in the annual mean surface temperature over Antarctica of about 10 K.

**Checklist:**

Please check all whether they apply or not
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules