### PR TITLE
Add instantaneous snow fraction diagnostic

### DIFF
--- a/FV3GFS/FV3GFS_io.F90
+++ b/FV3GFS/FV3GFS_io.F90
@@ -6825,6 +6825,17 @@ module FV3GFS_io_mod
 
     idx = idx + 1
     Diag(idx)%axes = 2
+    Diag(idx)%name = 'snow_cover'
+    Diag(idx)%desc = 'snow cover area fraction'
+    Diag(idx)%unit = 'fraction'
+    Diag(idx)%mod_name = 'gfs_sfc'
+    allocate (Diag(idx)%data(nblks))
+    do nb = 1,nblks
+      Diag(idx)%data(nb)%var2 => Sfcprop(nb)%sncovr(:)
+    enddo
+
+    idx = idx + 1
+    Diag(idx)%axes = 2
     Diag(idx)%name = 'crain'
     Diag(idx)%desc = 'instantaneous categorical rain'
     Diag(idx)%unit = 'number'

--- a/GFS_layer/GFS_physics_driver.F90
+++ b/GFS_layer/GFS_physics_driver.F90
@@ -743,15 +743,25 @@ module module_physics_driver
               Sfcprop%slmsk(i) = 2
               Sfcprop%hice(i) = 0.1 !minimum value
            elseif (nint(Sfcprop%slmsk(i)) == 2) then
-              if (Statein%ci(i) < 0.15) then !remove sea ice
+              if (Statein%ci(i) < 0.15) then ! Remove sea ice and associated snow
                  Sfcprop%slmsk(i) = 0
                  Sfcprop%fice(i) = 0.0
                  Sfcprop%hice(i) = 0.0
+                 Sfcprop%snowd(i) = 0.0
+                 Sfcprop%weasd(i) = 0.0
               else
                  Sfcprop%fice(i) = Statein%ci(i)
               endif
               
            endif
+        endif
+        if (nint(Sfcprop%slmsk(i)) .eq. 0) then
+           ! Always reset the snow cover fraction to zero over all ocean grid
+           ! cells regardless of whether we are running with sea ice prescribed
+           ! from an external source or not.  This is to prevent persisted
+           ! snow cover from sea ice from contaminating the snow cover
+           ! diagnostic over ocean (where it should always be zero).
+           Sfcprop%sncovr(i) = 0.0
         endif
       enddo
 


### PR DESCRIPTION
**Description**

This PR adds an instantaneous snow cover fraction diagnostic to SHiELD.  When plotting this field, one somewhat odd aspect that stood out is that the snow cover is non-zero over some ocean grid cells.  For the test run I did this was most noticeable in the North Pole tile.  This is illustrated in the figure below, which plots snapshots of the snow cover, snow depth, and snow water equivalent depth for the North Pole tile masked to only ocean grid cells.  The snow cover is non-zero at some points, but the snow depth and snow water equivalent depth are zero everywhere (which is more in line with what we would expect).

![2024-06-04-snow-fraction-ocean-mask](https://github.com/NOAA-GFDL/SHiELD_physics/assets/6628425/f41c1c6f-fb43-4555-9150-9c1f192a8819)

**How Has This Been Tested?**

This has been tested by running a short C24 resolution simulation and plotting the result for the diagnostic and comparing it with other snow-related diagnostics like the snow depth and snow water equivalent depth.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
