### PR TITLE
Add global mean CO2 diagnostic

### DIFF
--- a/GFS_layer/GFS_radiation_driver.F90
+++ b/GFS_layer/GFS_radiation_driver.F90
@@ -1958,7 +1958,7 @@
             delp = Statein%prsi(:,k) - Statein%prsi(:,k+1)
             h2ovmr = (con_amd / con_amw) * (Statein%qgrs(:,k,1) / (1 - Statein%qgrs(:,k,1)))
             am_moist_air = (1 - h2ovmr) * con_amd + h2ovmr * con_amw
-            moles_dry_air_per_square_meter =  delp / (con_g * am_moist_air * (1 + h2ovmr))
+            moles_dry_air_per_square_meter = delp / (con_g * am_moist_air * (1 + h2ovmr))
             Diag%column_moles_dry_air_per_square_meter = Diag%column_moles_dry_air_per_square_meter + moles_dry_air_per_square_meter
             Diag%column_moles_co2_per_square_meter = Diag%column_moles_co2_per_square_meter + moles_dry_air_per_square_meter * gasvmr(:,k,1)
          enddo

--- a/GFS_layer/GFS_radiation_driver.F90
+++ b/GFS_layer/GFS_radiation_driver.F90
@@ -309,7 +309,10 @@
       use physcons,                  only: eps   => con_eps,            &
      &                                     epsm1 => con_epsm1,          &
      &                                     fvirt => con_fvirt           &
-     &,                                    rocp  => con_rocp
+     &,                                    rocp  => con_rocp,           &
+     &                                     con_g,                       &
+     &                                     con_amd,                     &
+     &                                     con_amw
       use funcphys,                  only: fpvs
 
       use module_radiation_astronomy,only: sol_init, sol_update, coszmn
@@ -1379,6 +1382,12 @@
         Diag%co2 = gasvmr(:,:,1)  ! co2 volume mixing ratio
       endif
 
+      ! For diagnostic purposes, compute the column integrated moles of dry
+      ! air and moles of co2 per square meter following the method in
+      ! radlw_main.f.  These can be used later to compute a global mean carbon
+      ! dioxide volume mixing ratio diagnostic if requested.
+      call compute_column_integrated_moles_of_dry_air_and_co2(Statein, gasvmr, IM, LMK, NF_VGAS, Diag)
+
 !>  - Get temperature at layer interface, and layer moisture.
       do k = 2, LMK
         do i = 1, IM
@@ -1934,6 +1943,26 @@
       end subroutine GFS_radiation_driver
 !----------------------------------------
 
+      subroutine compute_column_integrated_moles_of_dry_air_and_co2(Statein, gasvmr, IM, LMK, NF_VGAS, Diag)
+         integer,                 intent(in)    :: IM, LMK, NF_VGAS
+         type(GFS_statein_type),  intent(in)    :: Statein
+         real(kind=kind_phys),    intent(in)    :: gasvmr(IM,LMK,NF_VGAS)
+         type(GFS_diag_type),     intent(inout) :: Diag
+
+         integer :: k
+         real(kind=kind_phys), dimension(IM) :: delp, h2ovmr, am_moist_air, moles_dry_air_per_square_meter
+
+         Diag%column_moles_co2_per_square_meter = 0.0
+         Diag%column_moles_dry_air_per_square_meter = 0.0
+         do k = 1, LMK
+            delp = Statein%prsi(:,k) - Statein%prsi(:,k+1)
+            h2ovmr = (con_amd / con_amw) * (Statein%qgrs(:,k,1) / (1 - Statein%qgrs(:,k,1)))
+            am_moist_air = (1 - h2ovmr) * con_amd + h2ovmr * con_amw
+            moles_dry_air_per_square_meter =  delp / (con_g * am_moist_air * (1 + h2ovmr))
+            Diag%column_moles_dry_air_per_square_meter = Diag%column_moles_dry_air_per_square_meter + moles_dry_air_per_square_meter
+            Diag%column_moles_co2_per_square_meter = Diag%column_moles_co2_per_square_meter + moles_dry_air_per_square_meter * gasvmr(:,k,1)
+         enddo
+      end subroutine compute_column_integrated_moles_of_dry_air_and_co2
 
 !
 !> @}

--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -1321,6 +1321,8 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: wu2_shal(:,:) => null()
     real (kind=kind_phys), pointer :: eta_shal(:,:) => null()
     real (kind=kind_phys), pointer :: co2(:,:) => null()  ! Vertically resolved CO2 concentration
+    real (kind=kind_phys), pointer :: column_moles_co2_per_square_meter(:) => null()  ! Moles of CO2 in column per square meter
+    real (kind=kind_phys), pointer :: column_moles_dry_air_per_square_meter(:) => null()  ! Moles of dry air in column per square meter
 
     !--- accumulated quantities for 3D diagnostics
     real (kind=kind_phys), pointer :: upd_mf (:,:)   => null()  !< instantaneous convective updraft mass flux
@@ -3924,6 +3926,8 @@ end subroutine overrides_create
       allocate (Diag%wu2_shal(IM,Model%levs))
       allocate (Diag%eta_shal(IM,Model%levs))
       allocate (Diag%co2(IM,Model%levs))
+      allocate (Diag%column_moles_co2_per_square_meter(IM))
+      allocate (Diag%column_moles_dry_air_per_square_meter(IM))
 
       !--- needed to allocate GoCart coupling fields
       allocate (Diag%upd_mf (IM,Model%levs))


### PR DESCRIPTION
**Description**

This PR adds a diagnostic for the global mean volume mixing ratio of CO2.  It does so following the conventions / approximations in `radlw_main.f`: https://github.com/NOAA-GFDL/SHiELD_physics/blob/5e5e100c068d55b8247dcb428f9df36fb31bdf35/gsmphys/radlw_main.f#L765-L806

It assumes the moles of CO2 per area can be computed by scaling the prescribed volume mixing ratio of CO2 by the moles of dry air per area.  A global mean volume mixing ratio then can be computed by dividing the total moles of CO2 globally the by the total moles of dry air globally.

**How Has This Been Tested?**

This has been tested in a three-month C24 simulation outputting the instantaneous global mean CO2 concentration every 6 hours.  The plot of the time series can be found below. 

![2024-06-05-global-mean-co2-diagnostic](https://github.com/NOAA-GFDL/SHiELD_physics/assets/6628425/27a2a013-e5fa-4a85-9e78-048c852e98aa)

The simulation uses `gfs_physics_nml.ico2 = 2`.  For globally uniform CO2 (e.g. with `gfs_physics_nml.ico2 = 1` and `gfs_physics_nml.ictm = 19970`), the diagnostic behaves as expected, producing a value exactly the same as that prescribed.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
