### PR TITLE
Add option to use a prescribed snow albedo with Noah-MP

### DIFF
--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -606,7 +606,7 @@ module GFS_typedefs
     integer              :: iopt_frz  !supercooled liquid water (1-> ny06; 2->koren99)
     integer              :: iopt_inf  !frozen soil permeability (1-> ny06; 2->koren99)
     integer              :: iopt_rad  !radiation transfer (1->gap=f(3d,cosz); 2->gap=0; 3->gap=1-fveg)
-    integer              :: iopt_alb  !snow surface albedo (1->bats; 2->class)
+    integer              :: iopt_alb  !snow surface albedo (1->bats; 2->class; 3->climatology)
     integer              :: iopt_snf  !rainfall & snowfall (1-jordan91; 2->bats; 3->noah)
     integer              :: iopt_tbot !lower boundary of soil temperature (1->zero-flux; 2->noah)
     integer              :: iopt_stc  !snow/soil temperature time scheme (only layer 1)

--- a/gsmphys/module_sf_noahmplsm.f90
+++ b/gsmphys/module_sf_noahmplsm.f90
@@ -110,7 +110,8 @@ module module_sf_noahmplsm
 
   integer :: opt_alb  ! options for ground snow surface albedo
                       !   1 -> bats
-		      ! **2 -> class
+                      ! **2 -> class
+                      !   3 -> prescribed from fix file climatology
 
   integer :: opt_snf  ! options for partitioning  precipitation into rainfall & snowfall
                       ! **1 -> jordan (1991)
@@ -285,6 +286,7 @@ contains
                    qc      , soldn   , lwdn    ,                               & ! in : forcing
 	           prcpconv, prcpnonc, prcpshcv, prcpsnow, prcpgrpl, prcphail, & ! in : forcing
                    tbot    , co2air  , o2air   , foln    , ficeold , zlvl    , & ! in : forcing
+                   snoalb  ,                                                   & ! in : forcing
                    albold  , sneqvo  ,                                         & ! in/out : 
                    stc     , sh2o    , smc     , tah     , eah     , fwet    , & ! in/out : 
                    canliq  , canice  , tv      , tg      , qsfc    , qsnow   , & ! in/out : 
@@ -355,6 +357,7 @@ contains
   real (kind=kind_phys)                           , intent(in)    :: dz8w   !thickness of lowest layer
   real (kind=kind_phys)                           , intent(in)    :: dx
   real (kind=kind_phys)                           , intent(in)    :: shdmax  !yearly max vegetation fraction
+  real (kind=kind_phys)                           , intent(in)    :: snoalb  ! prescribed snow albedo (only used if iopt_alb = 3)
 !jref:end
 
 
@@ -637,6 +640,7 @@ contains
                  elai   ,esai   ,fwet   ,foln   ,         & !in
                  fveg   ,pahv   ,pahg   ,pahb   ,                 & !in
                  qsnow  ,dzsnso ,lat    ,canliq ,canice ,iloc, jloc , & !in
+                 snoalb ,                                         & !in
 		 z0wrf  ,                                         &
                  imelt  ,snicev ,snliqv ,epore  ,t2m    ,fsno   , & !out
                  sav    ,sag    ,qmelt  ,fsa    ,fsr    ,taux   , & !out
@@ -1338,6 +1342,7 @@ contains
                      elai   ,esai   ,fwet   ,foln   ,         & !in
                      fveg   ,pahv   ,pahg   ,pahb   ,                 & !in
                      qsnow  ,dzsnso ,lat    ,canliq ,canice ,iloc   , jloc, & !in
+                     snoalb ,                                         & !in
 		     z0wrf  ,                                         &
                      imelt  ,snicev ,snliqv ,epore  ,t2m    ,fsno   , & !out
                      sav    ,sag    ,qmelt  ,fsa    ,fsr    ,taux   , & !out
@@ -1443,6 +1448,7 @@ contains
   real (kind=kind_phys)                              , intent(in)    :: dx     !horisontal resolution
   real (kind=kind_phys)                              , intent(in)    :: dz8w   !thickness of lowest layer
   real (kind=kind_phys)                              , intent(in)    :: q2     !mixing ratio (kg/kg)
+  real (kind=kind_phys)                              , intent(in)    :: snoalb !prescribed snow albedo (only used if iopt_alb = 3)
 !jref:end
 
 ! outputs
@@ -1703,6 +1709,7 @@ contains
                    tg      ,tv      ,fsno    ,qsnow   ,fwet    , & !in
                    elai    ,esai    ,smc     ,solad   ,solai   , & !in
                    fveg    ,iloc    ,jloc    ,                   & !in
+                   snoalb  ,                                     & !in
                    albold  ,tauss   ,                            & !inout
                    fsun    ,laisun  ,laisha  ,parsun  ,parsha  , & !out
                    sav     ,sag     ,fsr     ,fsa     ,fsrv    , & 
@@ -2244,6 +2251,7 @@ contains
                         tg      ,tv      ,fsno    ,qsnow   ,fwet    , & !in
                         elai    ,esai    ,smc     ,solad   ,solai   , & !in
                         fveg    ,iloc    ,jloc    ,                   & !in
+                        snoalb  ,                                     & !in
                         albold  ,tauss   ,                            & !inout
                         fsun    ,laisun  ,laisha  ,parsun  ,parsha  , & !out
                         sav     ,sag     ,fsr     ,fsa     ,fsrv    , &
@@ -2276,6 +2284,7 @@ contains
   real (kind=kind_phys), dimension(1:2)    , intent(in) :: solai  !incoming diffuse solar radiation (w/m2)
   real (kind=kind_phys), intent(in)                     :: fsno   !snow cover fraction (-)
   real (kind=kind_phys), intent(in)                     :: fveg   !green vegetation fraction [0.0-1.0]
+  real (kind=kind_phys), intent(in)                     :: snoalb !prescribed snow albedo (only used if iopt_alb = 3)
 
 ! inout
   real (kind=kind_phys),                  intent(inout) :: albold !snow albedo at last time step (class type)
@@ -2332,6 +2341,7 @@ contains
                 tg     ,tv     ,snowh  ,fsno   ,fwet   , & !in
                 smc    ,sneqvo ,sneqv  ,qsnow  ,fveg   , & !in
                 iloc   ,jloc   ,                         & !in
+                snoalb ,                                 & !in
                 albold ,tauss                          , & !inout
                 albgrd ,albgri ,albd   ,albi   ,fabd   , & !out
                 fabi   ,ftdd   ,ftid   ,ftii   ,fsun   , & !)   !out
@@ -2368,6 +2378,7 @@ contains
                      tg     ,tv     ,snowh  ,fsno   ,fwet   , & !in
                      smc    ,sneqvo ,sneqv  ,qsnow  ,fveg   , & !in
                      iloc   ,jloc   ,                         & !in
+                     snoalb ,                                 & !in
                      albold ,tauss                          , & !inout
                      albgrd ,albgri ,albd   ,albi   ,fabd   , & !out
                      fabi   ,ftdd   ,ftid   ,ftii   ,fsun   , & !out
@@ -2404,6 +2415,7 @@ contains
   real (kind=kind_phys),                     intent(in)  :: sneqv  !snow mass (mm)
   real (kind=kind_phys),                     intent(in)  :: fveg   !green vegetation fraction [0.0-1.0]
   real (kind=kind_phys), dimension(1:nsoil), intent(in)  :: smc    !volumetric soil water (m3/m3)
+  real (kind=kind_phys),                     intent(in)  :: snoalb !prescribed snow albedo (only used if iopt_alb = 3)
 
 ! inout
   real (kind=kind_phys),                  intent(inout)  :: albold !snow albedo at last time step (class type)
@@ -2492,11 +2504,14 @@ contains
 
 ! snow albedos: only if cosz > 0 and fsno > 0
 
-  if(opt_alb == 1) &
+  if(opt_alb == 1) then
      call snowalb_bats (parameters,nband, fsno,cosz,fage,albsnd,albsni)
-  if(opt_alb == 2) then
+  elseif(opt_alb == 2) then
      call snowalb_class (parameters,nband,qsnow,dt,alb,albold,albsnd,albsni,iloc,jloc)
      albold = alb
+  elseif(opt_alb == 3) then
+     albsnd = snoalb
+     albsni = snoalb
   end if
 
 ! ground surface albedo
@@ -8203,7 +8218,7 @@ end  subroutine shallowwatertable
   integer,  intent(in) :: iopt_frz  !supercooled liquid water (1-> ny06; 2->koren99)
   integer,  intent(in) :: iopt_inf  !frozen soil permeability (1-> ny06; 2->koren99)
   integer,  intent(in) :: iopt_rad  !radiation transfer (1->gap=f(3d,cosz); 2->gap=0; 3->gap=1-fveg)
-  integer,  intent(in) :: iopt_alb  !snow surface albedo (1->bats; 2->class)
+  integer,  intent(in) :: iopt_alb  !snow surface albedo (1->bats; 2->class; 3->climatology)
   integer,  intent(in) :: iopt_snf  !rainfall & snowfall (1-jordan91; 2->bats; 3->noah)
   integer,  intent(in) :: iopt_tbot !lower boundary of soil temperature (1->zero-flux; 2->noah)
 

--- a/gsmphys/sfc_noahmp_drv.f
+++ b/gsmphys/sfc_noahmp_drv.f
@@ -596,6 +596,7 @@
      &             i       ,1       ,cosz    ,nsnow   ,nsoil   ,delt  , & ! in : time/space/model-related
      &             sfctmp  ,sfcprs  ,uu      ,vv      ,q2      ,swdn  , & ! in : forcing
      &             prcp    ,lwdn    ,tbot    ,zlvl    ,ficeold ,zsoil , & ! in : forcing
+     &             snoalb1d,                                            & ! in : forcing
      &             qsnowx  ,sneqvox ,alboldx ,cmx     ,chx     ,isnowx, & ! in/out :sneqvox + alboldx -LST 
      &             swe  ,smsoil  ,zsnsox     ,snowh  ,snicex ,snliqx ,  & ! in/out : sneqvx + snowhx are avgd
      &             tgx     ,tsnsox  ,slsoil  ,taussx  ,qsfc1d         , & ! in/out : 
@@ -664,6 +665,7 @@
      &        qc      , swdn    , lwdn                                 ,& ! in : forcing
      &        pconv   , pnonc   , pshcv   , psnow   , pgrpl   , phail  ,& ! in : forcing
      &        tbot    , co2pp   , o2pp    , foln    , ficeold , zlvl   ,& ! in : forcing
+     &        snoalb1d                                                 ,& ! in : forcing
      &        alboldx , sneqvox                                        ,& ! in/out : 
      &        tsnsox  , slsoil  , smsoil  , tahx    , eahx    , fwetx  ,& ! in/out : 
      &        canliqx , canicex , tvx     , tgx     , qsfc1d  , qsnowx ,& ! in/out : 


### PR DESCRIPTION
**Description**

This PR builds on NOAA-GFDL/SHiELD_physics#46 and adds an option to also prescribe the snow albedo used by SHiELD when running with Noah-MP.  The existing options, which use schemes to dynamically set the snow albedo, result in an underestimate of the snow albedo, particularly in Antarctica.  This new option, which can be toggled by setting `gfs_physics_nml.iopt_alb = 3`, pipes in the maximum snow albedo read in from climatological fix files and uses that as the snow albedo within Noah-MP.  This happens to be the approach taken in SHiELD when using the Noah land surface model with `ialb = 1` (see [here](https://github.com/NOAA-GFDL/SHiELD_physics/blob/3027a97d8d828c0ebe1d5ebfbc2b1e44a79c5fdb/gsmphys/radiation_surface.f#L587-L623)), so there is precedent.

cc: @kaiyuan-cheng @lharris4 I rebased this branch now that #46 has been merged.  This should now be ready for review too.

**How Has This Been Tested?**

This has been tested by running a one month simulation initialized January 1st, 2020 from GFS analysis with prescribed observed sea surface temperatures and sea ice and computing the surface albedo bias relative to ERA5.  We can see that during this season that it makes a particular difference over Antarctica.  When coupled with the soil color update in NOAA-GFDL/SHiELD_physics#46 this results in land albedo biases more in line with those of SHiELD when run with Noah—compare the left and right-most panels of the plot below.

![2024-06-14-surface-albedo-diff-soil-color-and-snow-albedo-fix](https://github.com/spencerkclark/SHiELD_physics/assets/6628425/ede97256-e462-4a89-a4f4-779b54697207)

This climatological snow albedo is already stored and loaded from restart files by default, so no changes should be needed to ensure restart reproducibility.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules