### PR TITLE
Update parameters used for snow cover fraction scheme

### DIFF
--- a/gsmphys/module_sf_noahmplsm.f90
+++ b/gsmphys/module_sf_noahmplsm.f90
@@ -172,6 +172,7 @@ module module_sf_noahmplsm
     real (kind=kind_phys) :: den                !tree density (no. of trunks per m2)
     real (kind=kind_phys) :: rc                 !tree crown radius (m)
     real (kind=kind_phys) :: mfsno              !snowmelt m parameter ()
+    real (kind=kind_phys) :: scffac             !snow cover factor (m)
     real (kind=kind_phys) :: saim(12)           !monthly stem area index, one-sided
     real (kind=kind_phys) :: laim(12)           !monthly leaf area index, one-sided
     real (kind=kind_phys) :: sla                !single-side leaf area per kg [m2/kg]
@@ -1657,7 +1658,7 @@ contains
      if(snowh.gt.0.)  then
          bdsno    = sneqv / snowh
          fmelt    = (bdsno/100.)**parameters%mfsno
-         fsno     = tanh( snowh /(2.5* z0 * fmelt))
+         fsno     = tanh( snowh /(parameters%scffac * fmelt))
 !        print*,'bdsno=',bdsno,sneqv,snowh,parameters%mfsno,fmelt,fsno
      endif
 

--- a/gsmphys/noahmp_tables.f90
+++ b/gsmphys/noahmp_tables.f90
@@ -88,11 +88,20 @@ module noahmp_tables
      &                               0.30, 0.30, 0.00, 0.00, 0.00, 0.00,     &
      &                               0.00, 0.00, 0.00, 0.00, 0.00, 0.00 /
 
+    ! C. He 12/17/2020: optimized MFSNO values dependent on land type based on evaluation with SNOTEL SWE and MODIS SCF, surface albedo
     real (kind=kind_phys) :: mfsno_table(mvt)       !snowmelt curve parameter ()
-      data  ( mfsno_table(i),i=1,mvt) /  2.50, 2.50, 2.50, 2.50, 2.50, 2.50, &
-     &                               2.50, 2.50, 2.50, 2.50, 2.50, 2.50,     &
-     &                               2.50, 2.50, 2.50, 2.50, 2.50, 2.50,     &
-     &                               2.50, 2.50, 0.00, 0.00, 0.00, 0.00,     &
+      data  ( mfsno_table(i),i=1,mvt) /  1.00, 1.00, 1.00, 1.00, 1.00, 2.00, &
+     &                               2.00, 2.00, 2.00, 2.00, 3.00, 3.00,     &
+     &                               4.00, 4.00, 2.50, 3.00, 3.00, 3.50,     &
+     &                               3.50, 3.50, 0.00, 0.00, 0.00, 0.00,     &
+     &                               0.00, 0.00, 0.00, 0.00, 0.00, 0.00 /
+
+    ! C. He 12/17/2020: optimized snow cover factor (m) in SCF formulation to replace original constant 2.5*z0,z0=0.002m, based on evaluation with SNOTEL SWE and MODIS SCF, surface albedo
+    real (kind=kind_phys) :: scffac_table(mvt)       !snow cover factor (m)
+      data  ( scffac_table(i),i=1,mvt) /  0.005, 0.005, 0.005, 0.005, 0.005, 0.008, &
+     &                               0.008, 0.010, 0.010, 0.010, 0.010, 0.007,      &
+     &                               0.021, 0.013, 0.015, 0.008, 0.015, 0.015,      &
+     &                               0.015, 0.015, 0.00, 0.00, 0.00, 0.00,          &
      &                               0.00, 0.00, 0.00, 0.00, 0.00, 0.00 /
 
 !

--- a/gsmphys/sfc_noahmp_drv.f
+++ b/gsmphys/sfc_noahmp_drv.f
@@ -963,6 +963,7 @@
         parameters%den    =    den_table(vegtype)       !tree density (no. of trunks per m2)
         parameters%rc     =     rc_table(vegtype)       !tree crown radius (m)
         parameters%mfsno  =  mfsno_table(vegtype)       !snowmelt m parameter ()
+        parameters%scffac =  scffac_table(vegtype)      !snow cover factor (m)
         parameters%saim   =   saim_table(vegtype,:)     !monthly stem area index, one-sided
         parameters%laim   =   laim_table(vegtype,:)     !monthly leaf area index, one-sided
         parameters%sla    =    sla_table(vegtype)       !single-side leaf area per kg [m2/kg]


### PR DESCRIPTION
**Description**

This PR updates some parameters used in the snow cover fraction scheme of Noah-MP to be consistent with those in official version 4.5.  The commit that added these in the official Noah-MP repository is [here](https://github.com/NCAR/noahmp/commit/03690c5a2df0b6e4352f358f9dab5345c7bb1239).

cc: @kaiyuan-cheng @lharris4

**How Has This Been Tested?**

I have tested this in a year-long C24 resolution simulation with prescribed observed 2020 sea surface temperature and sea ice and compared the monthly mean surface albedo to ERA5.  Quantitatively in terms of land RMSE the differences are marginal, but it does seem to help the albedo bias be less systematically negative.

#### Before

![2024-06-17-albedo-bias-SHiELD-Noah-MP (soil color, iopt_alb = 3, iopt_snf = 3)](https://github.com/NOAA-GFDL/SHiELD_physics/assets/6628425/0efd9991-a502-4280-ae06-e51a819ebf9a)

#### After

![2024-06-17-albedo-bias-SHiELD-Noah-MP (soil color, iopt_alb = 3, iopt_snf = 3, scffac)](https://github.com/NOAA-GFDL/SHiELD_physics/assets/6628425/b0ccb7b5-f1c0-40db-8e71-077860b7b8da)

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
