### PR TITLE
fix bug when calling unallocated diagnostics

### DIFF
--- a/GFS_layer/GFS_radiation_driver.F90
+++ b/GFS_layer/GFS_radiation_driver.F90
@@ -1386,7 +1386,9 @@
       ! air and moles of co2 per square meter following the method in
       ! radlw_main.f.  These can be used later to compute a global mean carbon
       ! dioxide volume mixing ratio diagnostic if requested.
-      call compute_column_integrated_moles_of_dry_air_and_co2(Statein, gasvmr, IM, LMK, NF_VGAS, Diag)
+      if (Model%ldiag3d) then
+        call compute_column_integrated_moles_of_dry_air_and_co2(Statein, gasvmr, IM, LMK, NF_VGAS, Diag)
+      endif
 
 !>  - Get temperature at layer interface, and layer moisture.
       do k = 2, LMK

--- a/GFS_layer/GFS_radiation_driver.F90
+++ b/GFS_layer/GFS_radiation_driver.F90
@@ -1386,9 +1386,7 @@
       ! air and moles of co2 per square meter following the method in
       ! radlw_main.f.  These can be used later to compute a global mean carbon
       ! dioxide volume mixing ratio diagnostic if requested.
-      if (Model%ldiag3d) then
-        call compute_column_integrated_moles_of_dry_air_and_co2(Statein, gasvmr, IM, LMK, NF_VGAS, Diag)
-      endif
+      call compute_column_integrated_moles_of_dry_air_and_co2(Statein, gasvmr, IM, LMK, NF_VGAS, Diag)
 
 !>  - Get temperature at layer interface, and layer moisture.
       do k = 2, LMK

--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -3918,6 +3918,8 @@ end subroutine overrides_create
     allocate (Diag%pfr(IM,Model%levs))
     allocate (Diag%pfs(IM,Model%levs))
     allocate (Diag%pfg(IM,Model%levs))
+    allocate (Diag%column_moles_co2_per_square_meter(IM))
+    allocate (Diag%column_moles_dry_air_per_square_meter(IM))
 
     !--- 3D diagnostics
     if (Model%ldiag3d) then
@@ -3935,8 +3937,6 @@ end subroutine overrides_create
       allocate (Diag%wu2_shal(IM,Model%levs))
       allocate (Diag%eta_shal(IM,Model%levs))
       allocate (Diag%co2(IM,Model%levs))
-      allocate (Diag%column_moles_co2_per_square_meter(IM))
-      allocate (Diag%column_moles_dry_air_per_square_meter(IM))
 
       !--- needed to allocate GoCart coupling fields
       allocate (Diag%upd_mf (IM,Model%levs))


### PR DESCRIPTION
**Description**

The subroutine `compute_column_integrated_moles_of_dry_air_and_co2` is [called](https://github.com/NOAA-GFDL/SHiELD_physics/blob/main/GFS_layer/GFS_radiation_driver.F90#L1389) by default to compute:
`Diag%column_moles_dry_air_per_square_meter` and `Diag%column_moles_co2_per_square_meter` in [GFS_layer/GFS_radiation_driver.F90:](https://github.com/NOAA-GFDL/SHiELD_physics/blob/main/GFS_layer/GFS_radiation_driver.F90#L1946)


These quantities are not allocated in [GFS_layer/GFS_typedefs.F90](https://github.com/NOAA-GFDL/SHiELD_physics/blob/main/GFS_layer/GFS_typedefs.F90#L3923) if ldiag3d is false in gfs_physics_nml.
Thus, this causes a code crash.
This PR will add an if statement before calling compute_column_integrated_moles_of_dry_air_and_co2

Tested within shield in debug mode with the current public release branches.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x]  My changes generate no new warnings
- [] Any dependent changes have been merged and published in downstream modules
