### PR TITLE
Add optional radiative flux diagnostics with perturbed CO2

### DIFF
--- a/FV3GFS/FV3GFS_io.F90
+++ b/FV3GFS/FV3GFS_io.F90
@@ -3069,10 +3069,10 @@ module FV3GFS_io_mod
        Diag_diag_manager_controlled(index)%data(nb)%var21 => IntDiag(nb)%column_moles_dry_air_per_square_meter
    enddo
 
-   if (Model%do_radiation_double_call) then
-      do n = 1,Model%n_radiation_double_calls
+   if (Model%do_diagnostic_radiation_with_scaled_co2) then
+      do n = 1,Model%n_diagnostic_radiation_calls
          write (radiation_call,'(I1)') n
-         write (scaling,'(F6.2)') Model%radiation_double_call_co2_scale_factors(n)
+         write (scaling,'(F6.2)') Model%diagnostic_radiation_call_co2_scale_factors(n)
 
          index = index + 1
          Diag_diag_manager_controlled(index)%axes = 0
@@ -3083,7 +3083,7 @@ module FV3GFS_io_mod
          Diag_diag_manager_controlled(index)%coarse_graining_method = AREA_WEIGHTED
          allocate (Diag_diag_manager_controlled(index)%data(nblks))
          do nb = 1,nblks
-            Diag_diag_manager_controlled(index)%data(nb)%var2 => IntDiag(nb)%column_moles_co2_per_square_meter_radiation_double_call(n,:)
+            Diag_diag_manager_controlled(index)%data(nb)%var2 => IntDiag(nb)%column_moles_co2_per_square_meter_with_scaled_co2(n,:)
             Diag_diag_manager_controlled(index)%data(nb)%var21 => IntDiag(nb)%column_moles_dry_air_per_square_meter
          enddo
       enddo
@@ -3519,14 +3519,14 @@ module FV3GFS_io_mod
       Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%fluxr(:,1)
     enddo
 
-    if (Model%do_radiation_double_call) then
-       do n = 1,Model%n_radiation_double_calls
+    if (Model%do_diagnostic_radiation_with_scaled_co2) then
+       do n = 1,Model%n_diagnostic_radiation_calls
          write (xtra,'(I1)') n
-         write (scaling,'(F6.2)') Model%radiation_double_call_co2_scale_factors(n)
+         write (scaling,'(F6.2)') Model%diagnostic_radiation_call_co2_scale_factors(n)
 
          idx = idx + 1
          Diag(idx)%axes = 2
-         Diag(idx)%name = 'DSWRFtoa_double_call_' // trim(xtra)
+         Diag(idx)%name = 'DSWRFtoa_with_scaled_co2_' // trim(xtra)
          Diag(idx)%desc = 'top of atmos downward shortwave flux with ' // trim(adjustl(scaling)) // 'xCO2'
          Diag(idx)%unit = 'W/m**2'
          Diag(idx)%mod_name = 'gfs_phys'
@@ -3536,12 +3536,12 @@ module FV3GFS_io_mod
          Diag(idx)%intpl_method = 'bilinear'
          allocate (Diag(idx)%data(nblks))
          do nb = 1,nblks
-           Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswrftoa_double_call(n,:)
+           Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswrftoa_with_scaled_co2(n,:)
          enddo
 
          idx = idx + 1
          Diag(idx)%axes = 2
-         Diag(idx)%name = 'USWRFtoa_double_call_' // trim(xtra)
+         Diag(idx)%name = 'USWRFtoa_with_scaled_co2_' // trim(xtra)
          Diag(idx)%desc = 'top of atmos upward shortwave flux with ' // trim(adjustl(scaling)) // 'xCO2'
          Diag(idx)%unit = 'W/m**2'
          Diag(idx)%mod_name = 'gfs_phys'
@@ -3551,12 +3551,12 @@ module FV3GFS_io_mod
          Diag(idx)%intpl_method = 'bilinear'
          allocate (Diag(idx)%data(nblks))
          do nb = 1,nblks
-           Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswrftoa_double_call(n,:)
+           Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswrftoa_with_scaled_co2(n,:)
          enddo
 
          idx = idx + 1
          Diag(idx)%axes = 2
-         Diag(idx)%name = 'ULWRFtoa_double_call_' // trim(xtra)
+         Diag(idx)%name = 'ULWRFtoa_with_scaled_co2_' // trim(xtra)
          Diag(idx)%desc = 'top of atmos upward longwave flux with ' // trim(adjustl(scaling)) // 'xCO2'
          Diag(idx)%unit = 'W/m**2'
          Diag(idx)%mod_name = 'gfs_phys'
@@ -3566,7 +3566,7 @@ module FV3GFS_io_mod
          Diag(idx)%intpl_method = 'bilinear'
          allocate (Diag(idx)%data(nblks))
          do nb = 1,nblks
-           Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%ulwrftoa_double_call(n,:)
+           Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%ulwrftoa_with_scaled_co2(n,:)
          enddo
        enddo
     endif
@@ -4236,14 +4236,14 @@ module FV3GFS_io_mod
       Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%ulwsfc(:)
     enddo
 
-    if (Model%do_radiation_double_call) then
-       do n = 1,Model%n_radiation_double_calls
+    if (Model%do_diagnostic_radiation_with_scaled_co2) then
+       do n = 1,Model%n_diagnostic_radiation_calls
           write (xtra,'(I1)') n
-          write (scaling,'(F6.2)') Model%radiation_double_call_co2_scale_factors(n)
+          write (scaling,'(F6.2)') Model%diagnostic_radiation_call_co2_scale_factors(n)
 
           idx = idx + 1
           Diag(idx)%axes = 2
-          Diag(idx)%name = 'DSWRF_double_call_' // trim(xtra)
+          Diag(idx)%name = 'DSWRF_with_scaled_co2_' // trim(xtra)
           Diag(idx)%desc = 'Interval-averaged zenith-angle-adjusted downward shortwave flux at the surface with ' // trim(adjustl(scaling)) // 'xCO2'
           Diag(idx)%unit = 'w/m**2'
           Diag(idx)%mod_name = 'gfs_phys'
@@ -4252,12 +4252,12 @@ module FV3GFS_io_mod
           Diag(idx)%intpl_method = 'bilinear'
           allocate (Diag(idx)%data(nblks))
           do nb = 1,nblks
-             Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswsfc_double_call(n,:)
+             Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswsfc_with_scaled_co2(n,:)
           enddo
 
           idx = idx + 1
           Diag(idx)%axes = 2
-          Diag(idx)%name = 'USWRF_double_call_' // trim(xtra)
+          Diag(idx)%name = 'USWRF_with_scaled_co2_' // trim(xtra)
           Diag(idx)%desc = 'Interval-averaged zenith-angle-adjusted upward shortwave flux at the surface with ' // trim(adjustl(scaling)) // 'xCO2'
           Diag(idx)%unit = 'w/m**2'
           Diag(idx)%mod_name = 'gfs_phys'
@@ -4266,12 +4266,12 @@ module FV3GFS_io_mod
           Diag(idx)%intpl_method = 'bilinear'
           allocate (Diag(idx)%data(nblks))
           do nb = 1,nblks
-             Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswsfc_double_call(n,:)
+             Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswsfc_with_scaled_co2(n,:)
           enddo
 
           idx = idx + 1
           Diag(idx)%axes = 2
-          Diag(idx)%name = 'DLWRF_double_call_' // trim(xtra)
+          Diag(idx)%name = 'DLWRF_with_scaled_co2_' // trim(xtra)
           Diag(idx)%desc = 'Interval-averaged surface-temperature-adjusted downward longwave flux at the surface with ' // trim(adjustl(scaling)) // 'xCO2'
           Diag(idx)%unit = 'w/m**2'
           Diag(idx)%mod_name = 'gfs_phys'
@@ -4280,12 +4280,12 @@ module FV3GFS_io_mod
           Diag(idx)%intpl_method = 'bilinear'
           allocate (Diag(idx)%data(nblks))
           do nb = 1,nblks
-             Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfc_double_call(n,:)
+             Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfc_with_scaled_co2(n,:)
           enddo
 
           idx = idx + 1
           Diag(idx)%axes = 2
-          Diag(idx)%name = 'ULWRF_double_call_' // trim(xtra)
+          Diag(idx)%name = 'ULWRF_with_scaled_co2_' // trim(xtra)
           Diag(idx)%desc = 'Interval-averaged surface-temperature-adjusted upward longwave flux at the surface with ' // trim(adjustl(scaling)) // 'xCO2'
           Diag(idx)%unit = 'w/m**2'
           Diag(idx)%mod_name = 'gfs_phys'
@@ -4294,7 +4294,7 @@ module FV3GFS_io_mod
           Diag(idx)%intpl_method = 'bilinear'
           allocate (Diag(idx)%data(nblks))
           do nb = 1,nblks
-             Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%ulwsfc_double_call(n,:)
+             Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%ulwsfc_with_scaled_co2(n,:)
           enddo
        enddo
     endif
@@ -5102,57 +5102,57 @@ module FV3GFS_io_mod
       enddo
     endif
 
-    if (Model%do_radiation_double_call) then
-       do n = 1,Model%n_radiation_double_calls
+    if (Model%do_diagnostic_radiation_with_scaled_co2) then
+       do n = 1,Model%n_diagnostic_radiation_calls
           write (xtra,'(I1)') n
-          write (scaling,'(F6.2)') Model%radiation_double_call_co2_scale_factors(n)
+          write (scaling,'(F6.2)') Model%diagnostic_radiation_call_co2_scale_factors(n)
 
           idx = idx + 1
           Diag(idx)%axes = 2
-          Diag(idx)%name = 'DLWRFI_double_call_' // trim(xtra)
+          Diag(idx)%name = 'DLWRFI_with_scaled_co2_' // trim(xtra)
           Diag(idx)%desc = 'Instantaneous surface-temperature-adjusted downward longwave flux at the surface with ' // trim(adjustl(scaling)) // 'xCO2'
           Diag(idx)%unit = 'w/m**2'
           Diag(idx)%mod_name = 'gfs_phys'
           Diag(idx)%intpl_method = 'bilinear'
           allocate (Diag(idx)%data(nblks))
           do nb = 1,nblks
-              Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfci_double_call(n,:)
+              Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfci_with_scaled_co2(n,:)
           enddo
 
           idx = idx + 1
           Diag(idx)%axes = 2
-          Diag(idx)%name = 'ULWRFI_double_call_' // trim(xtra)
+          Diag(idx)%name = 'ULWRFI_with_scaled_co2_' // trim(xtra)
           Diag(idx)%desc = 'Instantaneous surface-temperature-adjusted upward longwave flux at the surface with ' // trim(adjustl(scaling)) // 'xCO2'
           Diag(idx)%unit = 'w/m**2'
           Diag(idx)%mod_name = 'gfs_phys'
           Diag(idx)%intpl_method = 'bilinear'
           allocate (Diag(idx)%data(nblks))
           do nb = 1,nblks
-             Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%ulwsfci_double_call(n,:)
+             Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%ulwsfci_with_scaled_co2(n,:)
           enddo
 
           idx = idx + 1
           Diag(idx)%axes = 2
-          Diag(idx)%name = 'DSWRFI_double_call_' // trim(xtra)
+          Diag(idx)%name = 'DSWRFI_with_scaled_co2_' // trim(xtra)
           Diag(idx)%desc = 'Instantaneous zenith-angle-adjusted downward shortwave flux at the surface with ' // trim(adjustl(scaling)) // 'xCO2'
           Diag(idx)%unit = 'w/m**2'
           Diag(idx)%mod_name = 'gfs_phys'
           Diag(idx)%intpl_method = 'bilinear'
           allocate (Diag(idx)%data(nblks))
           do nb = 1,nblks
-             Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswsfci_double_call(n,:)
+             Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswsfci_with_scaled_co2(n,:)
           enddo
 
           idx = idx + 1
           Diag(idx)%axes = 2
-          Diag(idx)%name = 'USWRFI_double_call_' // trim(xtra)
+          Diag(idx)%name = 'USWRFI_with_scaled_co2_' // trim(xtra)
           Diag(idx)%desc = 'Instantaneous zenith-angle-adjusted upward shortwave flux at the surface ' // trim(adjustl(scaling)) // 'xCO2'
           Diag(idx)%unit = 'w/m**2'
           Diag(idx)%mod_name = 'gfs_phys'
           Diag(idx)%intpl_method = 'bilinear'
           allocate (Diag(idx)%data(nblks))
           do nb = 1,nblks
-             Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswsfci_double_call(n,:)
+             Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswsfci_with_scaled_co2(n,:)
           enddo
        enddo
     endif

--- a/FV3GFS/FV3GFS_io.F90
+++ b/FV3GFS/FV3GFS_io.F90
@@ -3496,6 +3496,53 @@ module FV3GFS_io_mod
       Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%fluxr(:,1)
     enddo
 
+    if (Model%do_radiation_double_call) then
+       idx = idx + 1
+       Diag(idx)%axes = 2
+       Diag(idx)%name = 'DSWRFtoa_double_call'
+       Diag(idx)%desc = 'top of atmos downward shortwave flux [W/m**2]'
+       Diag(idx)%unit = 'W/m**2'
+       Diag(idx)%mod_name = 'gfs_phys'
+       Diag(idx)%cnvfac = cn_one
+       Diag(idx)%time_avg = .TRUE.
+       Diag(idx)%time_avg_kind = 'rad_sw'
+       Diag(idx)%intpl_method = 'bilinear'
+       allocate (Diag(idx)%data(nblks))
+       do nb = 1,nblks
+         Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswrftoa_double_call
+       enddo
+
+       idx = idx + 1
+       Diag(idx)%axes = 2
+       Diag(idx)%name = 'USWRFtoa_double_call'
+       Diag(idx)%desc = 'top of atmos upward shortwave flux [W/m**2]'
+       Diag(idx)%unit = 'W/m**2'
+       Diag(idx)%mod_name = 'gfs_phys'
+       Diag(idx)%cnvfac = cn_one
+       Diag(idx)%time_avg = .TRUE.
+       Diag(idx)%time_avg_kind = 'rad_sw'
+       Diag(idx)%intpl_method = 'bilinear'
+       allocate (Diag(idx)%data(nblks))
+       do nb = 1,nblks
+         Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswrftoa_double_call
+       enddo
+
+       idx = idx + 1
+       Diag(idx)%axes = 2
+       Diag(idx)%name = 'ULWRFtoa_double_call'
+       Diag(idx)%desc = 'top of atmos upward longwave flux [W/m**2]'
+       Diag(idx)%unit = 'W/m**2'
+       Diag(idx)%mod_name = 'gfs_phys'
+       Diag(idx)%cnvfac = cn_one
+       Diag(idx)%time_avg = .TRUE.
+       Diag(idx)%time_avg_kind = 'rad_lw'
+       Diag(idx)%intpl_method = 'bilinear'
+       allocate (Diag(idx)%data(nblks))
+       do nb = 1,nblks
+         Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%ulwrftoa_double_call
+       enddo
+    endif
+
     idx = idx + 1
     Diag(idx)%axes = 2
     Diag(idx)%name = 'TCDCclm'
@@ -4160,6 +4207,64 @@ module FV3GFS_io_mod
     do nb = 1,nblks
       Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%ulwsfc(:)
     enddo
+
+    if (Model%do_radiation_double_call) then
+       idx = idx + 1
+       Diag(idx)%axes = 2
+       Diag(idx)%name = 'DSWRF_double_call'
+       Diag(idx)%desc = 'Interval-averaged zenith-angle-adjusted downward shortwave flux at the surface'
+       Diag(idx)%unit = 'w/m**2'
+       Diag(idx)%mod_name = 'gfs_phys'
+       Diag(idx)%cnvfac = cn_one
+       Diag(idx)%time_avg = .TRUE.
+       Diag(idx)%intpl_method = 'bilinear'
+       allocate (Diag(idx)%data(nblks))
+       do nb = 1,nblks
+          Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswsfc_double_call(:)
+       enddo
+
+       idx = idx + 1
+       Diag(idx)%axes = 2
+       Diag(idx)%name = 'USWRF_double_call'
+       Diag(idx)%desc = 'Interval-averaged zenith-angle-adjusted upward shortwave flux at the surface'
+       Diag(idx)%unit = 'w/m**2'
+       Diag(idx)%mod_name = 'gfs_phys'
+       Diag(idx)%cnvfac = cn_one
+       Diag(idx)%time_avg = .TRUE.
+       Diag(idx)%intpl_method = 'bilinear'
+       allocate (Diag(idx)%data(nblks))
+       do nb = 1,nblks
+          Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswsfc_double_call(:)
+       enddo
+
+       idx = idx + 1
+       Diag(idx)%axes = 2
+       Diag(idx)%name = 'DLWRF_double_call'
+       Diag(idx)%desc = 'Interval-averaged surface-temperature-adjusted downward longwave flux at the surface'
+       Diag(idx)%unit = 'w/m**2'
+       Diag(idx)%mod_name = 'gfs_phys'
+       Diag(idx)%cnvfac = cn_one
+       Diag(idx)%time_avg = .TRUE.
+       Diag(idx)%intpl_method = 'bilinear'
+       allocate (Diag(idx)%data(nblks))
+       do nb = 1,nblks
+         Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfc_double_call(:)
+       enddo
+
+       idx = idx + 1
+       Diag(idx)%axes = 2
+       Diag(idx)%name = 'ULWRF_double_call'
+       Diag(idx)%desc = 'Interval-averaged surface-temperature-adjusted upward longwave flux at the surface'
+       Diag(idx)%unit = 'w/m**2'
+       Diag(idx)%mod_name = 'gfs_phys'
+       Diag(idx)%cnvfac = cn_one
+       Diag(idx)%time_avg = .TRUE.
+       Diag(idx)%intpl_method = 'bilinear'
+       allocate (Diag(idx)%data(nblks))
+       do nb = 1,nblks
+         Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%ulwsfc_double_call(:)
+       enddo
+    endif
 
     idx = idx + 1
     Diag(idx)%axes = 2
@@ -4962,6 +5067,56 @@ module FV3GFS_io_mod
       do nb = 1,nblks
         Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswsfci(:)
       enddo
+    endif
+
+    if (Model%do_radiation_double_call) then
+       idx = idx + 1
+       Diag(idx)%axes = 2
+       Diag(idx)%name = 'DLWRFI_double_call'
+       Diag(idx)%desc = 'Instantaneous surface-temperature-adjusted downward longwave flux at the surface'
+       Diag(idx)%unit = 'w/m**2'
+       Diag(idx)%mod_name = 'gfs_phys'
+       Diag(idx)%intpl_method = 'bilinear'
+       allocate (Diag(idx)%data(nblks))
+       do nb = 1,nblks
+          Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfci_double_call(:)
+       enddo
+
+       idx = idx + 1
+       Diag(idx)%axes = 2
+       Diag(idx)%name = 'ULWRFI_double_call'
+       Diag(idx)%desc = 'Instantaneous surface-temperature-adjusted upward longwave flux at the surface'
+       Diag(idx)%unit = 'w/m**2'
+       Diag(idx)%mod_name = 'gfs_phys'
+       Diag(idx)%intpl_method = 'bilinear'
+       allocate (Diag(idx)%data(nblks))
+       do nb = 1,nblks
+         Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%ulwsfci_double_call(:)
+       enddo
+
+       idx = idx + 1
+       Diag(idx)%axes = 2
+       Diag(idx)%name = 'DSWRFI_double_call'
+       Diag(idx)%desc = 'Instantaneous zenith-angle-adjusted downward shortwave flux at the surface'
+       Diag(idx)%unit = 'w/m**2'
+       Diag(idx)%mod_name = 'gfs_phys'
+       Diag(idx)%intpl_method = 'bilinear'
+       allocate (Diag(idx)%data(nblks))
+       do nb = 1,nblks
+          Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswsfci_double_call(:)
+       enddo
+
+       idx = idx + 1
+       Diag(idx)%axes = 2
+       Diag(idx)%name = 'USWRFI_double_call'
+       Diag(idx)%desc = 'Instantaneous zenith-angle-adjusted upward shortwave flux at the surface'
+       Diag(idx)%unit = 'w/m**2'
+       Diag(idx)%mod_name = 'gfs_phys'
+       Diag(idx)%intpl_method = 'bilinear'
+       allocate (Diag(idx)%data(nblks))
+       do nb = 1,nblks
+          Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswsfci_double_call(:)
+       enddo
     endif
 
     idx = idx + 1

--- a/FV3GFS/FV3GFS_io.F90
+++ b/FV3GFS/FV3GFS_io.F90
@@ -3072,7 +3072,7 @@ module FV3GFS_io_mod
    if (Model%do_diagnostic_radiation_with_scaled_co2) then
       do n = 1,Model%n_diagnostic_radiation_calls
          write (radiation_call,'(I1)') n
-         write (scaling,'(F6.2)') Model%diagnostic_radiation_call_co2_scale_factors(n)
+         write (scaling,'(F6.2)') Model%diagnostic_radiation_co2_scale_factors(n)
 
          index = index + 1
          Diag_diag_manager_controlled(index)%axes = 0
@@ -3522,7 +3522,7 @@ module FV3GFS_io_mod
     if (Model%do_diagnostic_radiation_with_scaled_co2) then
        do n = 1,Model%n_diagnostic_radiation_calls
          write (xtra,'(I1)') n
-         write (scaling,'(F6.2)') Model%diagnostic_radiation_call_co2_scale_factors(n)
+         write (scaling,'(F6.2)') Model%diagnostic_radiation_co2_scale_factors(n)
 
          idx = idx + 1
          Diag(idx)%axes = 2
@@ -4239,7 +4239,7 @@ module FV3GFS_io_mod
     if (Model%do_diagnostic_radiation_with_scaled_co2) then
        do n = 1,Model%n_diagnostic_radiation_calls
           write (xtra,'(I1)') n
-          write (scaling,'(F6.2)') Model%diagnostic_radiation_call_co2_scale_factors(n)
+          write (scaling,'(F6.2)') Model%diagnostic_radiation_co2_scale_factors(n)
 
           idx = idx + 1
           Diag(idx)%axes = 2
@@ -5105,7 +5105,7 @@ module FV3GFS_io_mod
     if (Model%do_diagnostic_radiation_with_scaled_co2) then
        do n = 1,Model%n_diagnostic_radiation_calls
           write (xtra,'(I1)') n
-          write (scaling,'(F6.2)') Model%diagnostic_radiation_call_co2_scale_factors(n)
+          write (scaling,'(F6.2)') Model%diagnostic_radiation_co2_scale_factors(n)
 
           idx = idx + 1
           Diag(idx)%axes = 2

--- a/FV3GFS/FV3GFS_io.F90
+++ b/FV3GFS/FV3GFS_io.F90
@@ -2699,7 +2699,9 @@ module FV3GFS_io_mod
     integer, intent(in) :: nblks
     integer, intent(in) :: axes(4)
 
-    integer :: nb
+    character(len=2) :: radiation_call
+    character(len=6) :: scaling
+    integer :: n, nb
     integer :: index = 1
 
     if (Model%ldiag3d) then
@@ -3067,6 +3069,26 @@ module FV3GFS_io_mod
        Diag_diag_manager_controlled(index)%data(nb)%var21 => IntDiag(nb)%column_moles_dry_air_per_square_meter
    enddo
 
+   if (Model%do_radiation_double_call) then
+      do n = 1,Model%n_radiation_double_calls
+         write (radiation_call,'(I1)') n
+         write (scaling,'(F6.2)') Model%radiation_double_call_co2_scale_factors(n)
+
+         index = index + 1
+         Diag_diag_manager_controlled(index)%axes = 0
+         Diag_diag_manager_controlled(index)%name = 'global_mean_co2_' // radiation_call
+         Diag_diag_manager_controlled(index)%desc = trim(adjustl(scaling)) // 'x global mean carbon dioxide concentration'
+         Diag_diag_manager_controlled(index)%unit = 'volume mixing ratio'
+         Diag_diag_manager_controlled(index)%mod_name = 'gfs_phys'
+         Diag_diag_manager_controlled(index)%coarse_graining_method = AREA_WEIGHTED
+         allocate (Diag_diag_manager_controlled(index)%data(nblks))
+         do nb = 1,nblks
+            Diag_diag_manager_controlled(index)%data(nb)%var2 => IntDiag(nb)%column_moles_co2_per_square_meter_radiation_double_call(n,:)
+            Diag_diag_manager_controlled(index)%data(nb)%var21 => IntDiag(nb)%column_moles_dry_air_per_square_meter
+         enddo
+      enddo
+   endif
+
    index = index + 1
    Diag_diag_manager_controlled(index)%axes = 2
    Diag_diag_manager_controlled(index)%name = 'ocean_fraction'
@@ -3182,9 +3204,10 @@ module FV3GFS_io_mod
     type (block_control_type), intent(in) :: Atm_block
     integer, dimension(4),     intent(in) :: axes
 !--- local variables
-    integer :: idx, num, nb, nblks, nx, ny, k
+    integer :: idx, num, nb, nblks, nx, ny, k, n
     integer, allocatable :: blksz(:)
     character(len=2) :: xtra
+    character(len=6) :: scaling
     real(kind=kind_phys), parameter :: cn_one = 1._kind_phys
     real(kind=kind_phys), parameter :: cn_100 = 100._kind_phys
     real(kind=kind_phys), parameter :: cn_th  = 1000._kind_phys
@@ -3497,49 +3520,54 @@ module FV3GFS_io_mod
     enddo
 
     if (Model%do_radiation_double_call) then
-       idx = idx + 1
-       Diag(idx)%axes = 2
-       Diag(idx)%name = 'DSWRFtoa_double_call'
-       Diag(idx)%desc = 'top of atmos downward shortwave flux [W/m**2]'
-       Diag(idx)%unit = 'W/m**2'
-       Diag(idx)%mod_name = 'gfs_phys'
-       Diag(idx)%cnvfac = cn_one
-       Diag(idx)%time_avg = .TRUE.
-       Diag(idx)%time_avg_kind = 'rad_sw'
-       Diag(idx)%intpl_method = 'bilinear'
-       allocate (Diag(idx)%data(nblks))
-       do nb = 1,nblks
-         Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswrftoa_double_call
-       enddo
+       do n = 1,Model%n_radiation_double_calls
+         write (xtra,'(I1)') n
+         write (scaling,'(F6.2)') Model%radiation_double_call_co2_scale_factors(n)
 
-       idx = idx + 1
-       Diag(idx)%axes = 2
-       Diag(idx)%name = 'USWRFtoa_double_call'
-       Diag(idx)%desc = 'top of atmos upward shortwave flux [W/m**2]'
-       Diag(idx)%unit = 'W/m**2'
-       Diag(idx)%mod_name = 'gfs_phys'
-       Diag(idx)%cnvfac = cn_one
-       Diag(idx)%time_avg = .TRUE.
-       Diag(idx)%time_avg_kind = 'rad_sw'
-       Diag(idx)%intpl_method = 'bilinear'
-       allocate (Diag(idx)%data(nblks))
-       do nb = 1,nblks
-         Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswrftoa_double_call
-       enddo
+         idx = idx + 1
+         Diag(idx)%axes = 2
+         Diag(idx)%name = 'DSWRFtoa_double_call_' // trim(xtra)
+         Diag(idx)%desc = 'top of atmos downward shortwave flux with ' // trim(adjustl(scaling)) // 'xCO2'
+         Diag(idx)%unit = 'W/m**2'
+         Diag(idx)%mod_name = 'gfs_phys'
+         Diag(idx)%cnvfac = cn_one
+         Diag(idx)%time_avg = .TRUE.
+         Diag(idx)%time_avg_kind = 'rad_sw'
+         Diag(idx)%intpl_method = 'bilinear'
+         allocate (Diag(idx)%data(nblks))
+         do nb = 1,nblks
+           Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswrftoa_double_call(n,:)
+         enddo
 
-       idx = idx + 1
-       Diag(idx)%axes = 2
-       Diag(idx)%name = 'ULWRFtoa_double_call'
-       Diag(idx)%desc = 'top of atmos upward longwave flux [W/m**2]'
-       Diag(idx)%unit = 'W/m**2'
-       Diag(idx)%mod_name = 'gfs_phys'
-       Diag(idx)%cnvfac = cn_one
-       Diag(idx)%time_avg = .TRUE.
-       Diag(idx)%time_avg_kind = 'rad_lw'
-       Diag(idx)%intpl_method = 'bilinear'
-       allocate (Diag(idx)%data(nblks))
-       do nb = 1,nblks
-         Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%ulwrftoa_double_call
+         idx = idx + 1
+         Diag(idx)%axes = 2
+         Diag(idx)%name = 'USWRFtoa_double_call_' // trim(xtra)
+         Diag(idx)%desc = 'top of atmos upward shortwave flux with ' // trim(adjustl(scaling)) // 'xCO2'
+         Diag(idx)%unit = 'W/m**2'
+         Diag(idx)%mod_name = 'gfs_phys'
+         Diag(idx)%cnvfac = cn_one
+         Diag(idx)%time_avg = .TRUE.
+         Diag(idx)%time_avg_kind = 'rad_sw'
+         Diag(idx)%intpl_method = 'bilinear'
+         allocate (Diag(idx)%data(nblks))
+         do nb = 1,nblks
+           Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswrftoa_double_call(n,:)
+         enddo
+
+         idx = idx + 1
+         Diag(idx)%axes = 2
+         Diag(idx)%name = 'ULWRFtoa_double_call_' // trim(xtra)
+         Diag(idx)%desc = 'top of atmos upward longwave flux with ' // trim(adjustl(scaling)) // 'xCO2'
+         Diag(idx)%unit = 'W/m**2'
+         Diag(idx)%mod_name = 'gfs_phys'
+         Diag(idx)%cnvfac = cn_one
+         Diag(idx)%time_avg = .TRUE.
+         Diag(idx)%time_avg_kind = 'rad_lw'
+         Diag(idx)%intpl_method = 'bilinear'
+         allocate (Diag(idx)%data(nblks))
+         do nb = 1,nblks
+           Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%ulwrftoa_double_call(n,:)
+         enddo
        enddo
     endif
 
@@ -4209,60 +4237,65 @@ module FV3GFS_io_mod
     enddo
 
     if (Model%do_radiation_double_call) then
-       idx = idx + 1
-       Diag(idx)%axes = 2
-       Diag(idx)%name = 'DSWRF_double_call'
-       Diag(idx)%desc = 'Interval-averaged zenith-angle-adjusted downward shortwave flux at the surface'
-       Diag(idx)%unit = 'w/m**2'
-       Diag(idx)%mod_name = 'gfs_phys'
-       Diag(idx)%cnvfac = cn_one
-       Diag(idx)%time_avg = .TRUE.
-       Diag(idx)%intpl_method = 'bilinear'
-       allocate (Diag(idx)%data(nblks))
-       do nb = 1,nblks
-          Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswsfc_double_call(:)
-       enddo
+       do n = 1,Model%n_radiation_double_calls
+          write (xtra,'(I1)') n
+          write (scaling,'(F6.2)') Model%radiation_double_call_co2_scale_factors(n)
 
-       idx = idx + 1
-       Diag(idx)%axes = 2
-       Diag(idx)%name = 'USWRF_double_call'
-       Diag(idx)%desc = 'Interval-averaged zenith-angle-adjusted upward shortwave flux at the surface'
-       Diag(idx)%unit = 'w/m**2'
-       Diag(idx)%mod_name = 'gfs_phys'
-       Diag(idx)%cnvfac = cn_one
-       Diag(idx)%time_avg = .TRUE.
-       Diag(idx)%intpl_method = 'bilinear'
-       allocate (Diag(idx)%data(nblks))
-       do nb = 1,nblks
-          Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswsfc_double_call(:)
-       enddo
+          idx = idx + 1
+          Diag(idx)%axes = 2
+          Diag(idx)%name = 'DSWRF_double_call_' // trim(xtra)
+          Diag(idx)%desc = 'Interval-averaged zenith-angle-adjusted downward shortwave flux at the surface with ' // trim(adjustl(scaling)) // 'xCO2'
+          Diag(idx)%unit = 'w/m**2'
+          Diag(idx)%mod_name = 'gfs_phys'
+          Diag(idx)%cnvfac = cn_one
+          Diag(idx)%time_avg = .TRUE.
+          Diag(idx)%intpl_method = 'bilinear'
+          allocate (Diag(idx)%data(nblks))
+          do nb = 1,nblks
+             Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswsfc_double_call(n,:)
+          enddo
 
-       idx = idx + 1
-       Diag(idx)%axes = 2
-       Diag(idx)%name = 'DLWRF_double_call'
-       Diag(idx)%desc = 'Interval-averaged surface-temperature-adjusted downward longwave flux at the surface'
-       Diag(idx)%unit = 'w/m**2'
-       Diag(idx)%mod_name = 'gfs_phys'
-       Diag(idx)%cnvfac = cn_one
-       Diag(idx)%time_avg = .TRUE.
-       Diag(idx)%intpl_method = 'bilinear'
-       allocate (Diag(idx)%data(nblks))
-       do nb = 1,nblks
-         Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfc_double_call(:)
-       enddo
+          idx = idx + 1
+          Diag(idx)%axes = 2
+          Diag(idx)%name = 'USWRF_double_call_' // trim(xtra)
+          Diag(idx)%desc = 'Interval-averaged zenith-angle-adjusted upward shortwave flux at the surface with ' // trim(adjustl(scaling)) // 'xCO2'
+          Diag(idx)%unit = 'w/m**2'
+          Diag(idx)%mod_name = 'gfs_phys'
+          Diag(idx)%cnvfac = cn_one
+          Diag(idx)%time_avg = .TRUE.
+          Diag(idx)%intpl_method = 'bilinear'
+          allocate (Diag(idx)%data(nblks))
+          do nb = 1,nblks
+             Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswsfc_double_call(n,:)
+          enddo
 
-       idx = idx + 1
-       Diag(idx)%axes = 2
-       Diag(idx)%name = 'ULWRF_double_call'
-       Diag(idx)%desc = 'Interval-averaged surface-temperature-adjusted upward longwave flux at the surface'
-       Diag(idx)%unit = 'w/m**2'
-       Diag(idx)%mod_name = 'gfs_phys'
-       Diag(idx)%cnvfac = cn_one
-       Diag(idx)%time_avg = .TRUE.
-       Diag(idx)%intpl_method = 'bilinear'
-       allocate (Diag(idx)%data(nblks))
-       do nb = 1,nblks
-         Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%ulwsfc_double_call(:)
+          idx = idx + 1
+          Diag(idx)%axes = 2
+          Diag(idx)%name = 'DLWRF_double_call_' // trim(xtra)
+          Diag(idx)%desc = 'Interval-averaged surface-temperature-adjusted downward longwave flux at the surface with ' // trim(adjustl(scaling)) // 'xCO2'
+          Diag(idx)%unit = 'w/m**2'
+          Diag(idx)%mod_name = 'gfs_phys'
+          Diag(idx)%cnvfac = cn_one
+          Diag(idx)%time_avg = .TRUE.
+          Diag(idx)%intpl_method = 'bilinear'
+          allocate (Diag(idx)%data(nblks))
+          do nb = 1,nblks
+             Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfc_double_call(n,:)
+          enddo
+
+          idx = idx + 1
+          Diag(idx)%axes = 2
+          Diag(idx)%name = 'ULWRF_double_call_' // trim(xtra)
+          Diag(idx)%desc = 'Interval-averaged surface-temperature-adjusted upward longwave flux at the surface with ' // trim(adjustl(scaling)) // 'xCO2'
+          Diag(idx)%unit = 'w/m**2'
+          Diag(idx)%mod_name = 'gfs_phys'
+          Diag(idx)%cnvfac = cn_one
+          Diag(idx)%time_avg = .TRUE.
+          Diag(idx)%intpl_method = 'bilinear'
+          allocate (Diag(idx)%data(nblks))
+          do nb = 1,nblks
+             Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%ulwsfc_double_call(n,:)
+          enddo
        enddo
     endif
 
@@ -5070,52 +5103,57 @@ module FV3GFS_io_mod
     endif
 
     if (Model%do_radiation_double_call) then
-       idx = idx + 1
-       Diag(idx)%axes = 2
-       Diag(idx)%name = 'DLWRFI_double_call'
-       Diag(idx)%desc = 'Instantaneous surface-temperature-adjusted downward longwave flux at the surface'
-       Diag(idx)%unit = 'w/m**2'
-       Diag(idx)%mod_name = 'gfs_phys'
-       Diag(idx)%intpl_method = 'bilinear'
-       allocate (Diag(idx)%data(nblks))
-       do nb = 1,nblks
-          Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfci_double_call(:)
-       enddo
+       do n = 1,Model%n_radiation_double_calls
+          write (xtra,'(I1)') n
+          write (scaling,'(F6.2)') Model%radiation_double_call_co2_scale_factors(n)
 
-       idx = idx + 1
-       Diag(idx)%axes = 2
-       Diag(idx)%name = 'ULWRFI_double_call'
-       Diag(idx)%desc = 'Instantaneous surface-temperature-adjusted upward longwave flux at the surface'
-       Diag(idx)%unit = 'w/m**2'
-       Diag(idx)%mod_name = 'gfs_phys'
-       Diag(idx)%intpl_method = 'bilinear'
-       allocate (Diag(idx)%data(nblks))
-       do nb = 1,nblks
-         Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%ulwsfci_double_call(:)
-       enddo
+          idx = idx + 1
+          Diag(idx)%axes = 2
+          Diag(idx)%name = 'DLWRFI_double_call_' // trim(xtra)
+          Diag(idx)%desc = 'Instantaneous surface-temperature-adjusted downward longwave flux at the surface with ' // trim(adjustl(scaling)) // 'xCO2'
+          Diag(idx)%unit = 'w/m**2'
+          Diag(idx)%mod_name = 'gfs_phys'
+          Diag(idx)%intpl_method = 'bilinear'
+          allocate (Diag(idx)%data(nblks))
+          do nb = 1,nblks
+              Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dlwsfci_double_call(n,:)
+          enddo
 
-       idx = idx + 1
-       Diag(idx)%axes = 2
-       Diag(idx)%name = 'DSWRFI_double_call'
-       Diag(idx)%desc = 'Instantaneous zenith-angle-adjusted downward shortwave flux at the surface'
-       Diag(idx)%unit = 'w/m**2'
-       Diag(idx)%mod_name = 'gfs_phys'
-       Diag(idx)%intpl_method = 'bilinear'
-       allocate (Diag(idx)%data(nblks))
-       do nb = 1,nblks
-          Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswsfci_double_call(:)
-       enddo
+          idx = idx + 1
+          Diag(idx)%axes = 2
+          Diag(idx)%name = 'ULWRFI_double_call_' // trim(xtra)
+          Diag(idx)%desc = 'Instantaneous surface-temperature-adjusted upward longwave flux at the surface with ' // trim(adjustl(scaling)) // 'xCO2'
+          Diag(idx)%unit = 'w/m**2'
+          Diag(idx)%mod_name = 'gfs_phys'
+          Diag(idx)%intpl_method = 'bilinear'
+          allocate (Diag(idx)%data(nblks))
+          do nb = 1,nblks
+             Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%ulwsfci_double_call(n,:)
+          enddo
 
-       idx = idx + 1
-       Diag(idx)%axes = 2
-       Diag(idx)%name = 'USWRFI_double_call'
-       Diag(idx)%desc = 'Instantaneous zenith-angle-adjusted upward shortwave flux at the surface'
-       Diag(idx)%unit = 'w/m**2'
-       Diag(idx)%mod_name = 'gfs_phys'
-       Diag(idx)%intpl_method = 'bilinear'
-       allocate (Diag(idx)%data(nblks))
-       do nb = 1,nblks
-          Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswsfci_double_call(:)
+          idx = idx + 1
+          Diag(idx)%axes = 2
+          Diag(idx)%name = 'DSWRFI_double_call_' // trim(xtra)
+          Diag(idx)%desc = 'Instantaneous zenith-angle-adjusted downward shortwave flux at the surface with ' // trim(adjustl(scaling)) // 'xCO2'
+          Diag(idx)%unit = 'w/m**2'
+          Diag(idx)%mod_name = 'gfs_phys'
+          Diag(idx)%intpl_method = 'bilinear'
+          allocate (Diag(idx)%data(nblks))
+          do nb = 1,nblks
+             Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswsfci_double_call(n,:)
+          enddo
+
+          idx = idx + 1
+          Diag(idx)%axes = 2
+          Diag(idx)%name = 'USWRFI_double_call_' // trim(xtra)
+          Diag(idx)%desc = 'Instantaneous zenith-angle-adjusted upward shortwave flux at the surface ' // trim(adjustl(scaling)) // 'xCO2'
+          Diag(idx)%unit = 'w/m**2'
+          Diag(idx)%mod_name = 'gfs_phys'
+          Diag(idx)%intpl_method = 'bilinear'
+          allocate (Diag(idx)%data(nblks))
+          do nb = 1,nblks
+             Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswsfci_double_call(n,:)
+          enddo
        enddo
     endif
 
@@ -7531,13 +7569,13 @@ module FV3GFS_io_mod
               call mpp_error(FATAL, 'Invalid coarse-graining strategy provided.')
             endif
           endif
-        elseif (trim(Diag_diag_manager_controlled(index)%name) .eq. 'global_mean_co2') then
+        elseif (starts_with(Diag_diag_manager_controlled(index)%name, 'global_mean_co2')) then
           if (Diag_diag_manager_controlled(index)%id > 0) then
              call compute_global_mean_co2(Atm_block, IPD_Data, nx, ny, Diag_diag_manager_controlled(index), scalar)
              used = send_data(Diag_diag_manager_controlled(index)%id, scalar, Time)
           endif
           if (Diag_diag_manager_controlled_coarse(index)%id > 0) then
-             call mpp_error(FATAL, 'global_mean_co2_coarse is not a valid diagnostic; use global_mean_co2 instead.')
+             call mpp_error(FATAL, trim(Diag_diag_manager_controlled_coarse(index)%name) // ' is not a valid diagnostic; use ' // trim(Diag_diag_manager_controlled(index)%name) // ' instead.')
           endif
         endif
       endif
@@ -8343,6 +8381,15 @@ module FV3GFS_io_mod
     endif
     used = send_data(id, coarse, Time)
 end subroutine store_data3D_coarse_pressure_level
+
+function starts_with(string, prefix)
+   character(len=128), intent(in) :: string
+   character(len=*), intent(in) :: prefix
+   logical :: starts_with
+
+   starts_with = string(1:len(trim(prefix))) .eq. trim(prefix)
+   return
+end function starts_with
 
 end module FV3GFS_io_mod
 

--- a/GFS_layer/GFS_physics_driver.F90
+++ b/GFS_layer/GFS_physics_driver.F90
@@ -474,7 +474,7 @@ module module_physics_driver
            !--- for CS-convection
            wcbmax
            
-      real(kind=kind_phys), allocatable, dimension(:) :: adjsfcdsw_double_call, &
+      real(kind=kind_phys), allocatable, dimension(:,:) :: adjsfcdsw_double_call, &
            adjsfcnsw_double_call, adjsfcdlw_double_call, adjsfculw_double_call, &
            adjnirbmu_double_call, adjnirdfu_double_call, adjvisbmu_double_call, &
            adjvisdfu_double_call, adjnirbmd_double_call, adjnirdfd_double_call, &
@@ -513,7 +513,7 @@ module module_physics_driver
           sigmatot, sigmafrac, specific_heat, final_dynamics_delp, dtdt_gwdps, &
           wu2_shal,  eta_shal 
 
-      real(kind=kind_phys), allocatable, dimension(:,:) :: dtdt_double_call, dtdtc_double_call
+      real(kind=kind_phys), allocatable, dimension(:,:,:) :: dtdt_double_call, dtdtc_double_call
 
       real(kind=kind_phys), allocatable ::                              &
            pfr(:,:), pfs(:,:), pfg(:,:)
@@ -894,45 +894,47 @@ module module_physics_driver
            )
 
         if (Model%do_radiation_double_call) then
-           allocate(dtdt_double_call(size(Grid%xlon,1),Model%levs))
-           allocate(dtdtc_double_call(size(Grid%xlon,1),Model%levs))
+           allocate(dtdt_double_call(Model%n_radiation_double_calls,size(Grid%xlon,1),Model%levs))
+           allocate(dtdtc_double_call(Model%n_radiation_double_calls,size(Grid%xlon,1),Model%levs))
 
-           allocate(adjsfcdsw_double_call(size(Grid%xlon,1)))
-           allocate(adjsfcnsw_double_call(size(Grid%xlon,1)))
-           allocate(adjsfcdlw_double_call(size(Grid%xlon,1)))
-           allocate(adjsfculw_double_call(size(Grid%xlon,1)))
-           allocate(adjnirbmu_double_call(size(Grid%xlon,1)))
-           allocate(adjnirdfu_double_call(size(Grid%xlon,1)))
-           allocate(adjvisbmu_double_call(size(Grid%xlon,1)))
-           allocate(adjvisdfu_double_call(size(Grid%xlon,1)))
-           allocate(adjnirbmd_double_call(size(Grid%xlon,1)))
-           allocate(adjnirdfd_double_call(size(Grid%xlon,1)))
-           allocate(adjvisbmd_double_call(size(Grid%xlon,1)))
-           allocate(adjvisdfd_double_call(size(Grid%xlon,1)))
+           allocate(adjsfcdsw_double_call(Model%n_radiation_double_calls,size(Grid%xlon,1)))
+           allocate(adjsfcnsw_double_call(Model%n_radiation_double_calls,size(Grid%xlon,1)))
+           allocate(adjsfcdlw_double_call(Model%n_radiation_double_calls,size(Grid%xlon,1)))
+           allocate(adjsfculw_double_call(Model%n_radiation_double_calls,size(Grid%xlon,1)))
+           allocate(adjnirbmu_double_call(Model%n_radiation_double_calls,size(Grid%xlon,1)))
+           allocate(adjnirdfu_double_call(Model%n_radiation_double_calls,size(Grid%xlon,1)))
+           allocate(adjvisbmu_double_call(Model%n_radiation_double_calls,size(Grid%xlon,1)))
+           allocate(adjvisdfu_double_call(Model%n_radiation_double_calls,size(Grid%xlon,1)))
+           allocate(adjnirbmd_double_call(Model%n_radiation_double_calls,size(Grid%xlon,1)))
+           allocate(adjnirdfd_double_call(Model%n_radiation_double_calls,size(Grid%xlon,1)))
+           allocate(adjvisbmd_double_call(Model%n_radiation_double_calls,size(Grid%xlon,1)))
+           allocate(adjvisdfd_double_call(Model%n_radiation_double_calls,size(Grid%xlon,1)))
 
-           allocate(xmu_double_call(size(Grid%xlon,1)))
-           allocate(xcosz_double_call(size(Grid%xlon,1)))
+           allocate(xmu_double_call(Model%n_radiation_double_calls,size(Grid%xlon,1)))
+           allocate(xcosz_double_call(Model%n_radiation_double_calls,size(Grid%xlon,1)))
 
-           call dcyc2t3                                                        &
-   !  ---  inputs:
-           ! TODO(spencer): do we need to worry about updating Radtend%tsflw for the double call?
-             ( Model%solhr, Model%slag, Model%sdec, Model%cdec, Grid%sinlat,                                                  &
-               Grid%coslat, Grid%xlon, Radtend%coszen, Sfcprop%tsfc,                                                          &
-               Statein%tgrs(1,1), Radtend%tsflw, Radtend%semis,                                                               &
-               Coupling%sfcdsw_double_call, Coupling%sfcnsw_double_call, Coupling%sfcdlw_double_call,                         &
-               Radtend%htrsw_double_call, Radtend%swhc_double_call, Radtend%htrlw_double_call, Radtend%lwhc_double_call,      &
-               Coupling%nirbmui_double_call, Coupling%nirdfui_double_call, Coupling%visbmui_double_call,                      &
-               Coupling%visdfui_double_call, Coupling%nirbmdi_double_call, Coupling%nirdfdi_double_call,                      &
-               Coupling%visbmdi_double_call, Coupling%visdfdi_double_call, ix, im, levs,                                      &
-               Model%daily_mean,                                                                                              &
-   !  ---  input/output:
-               dtdt_double_call, dtdtc_double_call,                                                                           &
-   !  ---  outputs:
-               adjsfcdsw_double_call, adjsfcnsw_double_call, adjsfcdlw_double_call, adjsfculw_double_call,                    &
-               xmu_double_call, xcosz_double_call,                                                                            &
-               adjnirbmu_double_call, adjnirdfu_double_call, adjvisbmu_double_call, adjvisdfu_double_call,                    &
-               adjnirbmd_double_call, adjnirdfd_double_call, adjvisbmd_double_call, adjvisdfd_double_call                     &
-             )
+           do n = 1,Model%n_radiation_double_calls
+              call dcyc2t3                                                                                                                                    &
+       !  ---  inputs:
+               ! TODO(spencer): do we need to worry about updating Radtend%tsflw for the double call?
+                 ( Model%solhr, Model%slag, Model%sdec, Model%cdec, Grid%sinlat,                                                                              &
+                   Grid%coslat, Grid%xlon, Radtend%coszen, Sfcprop%tsfc,                                                                                      &
+                   Statein%tgrs(1,1), Radtend%tsflw, Radtend%semis,                                                                                           &
+                   Coupling%sfcdsw_double_call(n,:), Coupling%sfcnsw_double_call(n,:), Coupling%sfcdlw_double_call(n,:),                                      &
+                   Radtend%htrsw_double_call(n,:,:), Radtend%swhc_double_call(n,:,:), Radtend%htrlw_double_call(n,:,:), Radtend%lwhc_double_call(n,:,:),      &
+                   Coupling%nirbmui_double_call(n,:), Coupling%nirdfui_double_call(n,:), Coupling%visbmui_double_call(n,:),                                   &
+                   Coupling%visdfui_double_call(n,:), Coupling%nirbmdi_double_call(n,:), Coupling%nirdfdi_double_call(n,:),                                   &
+                   Coupling%visbmdi_double_call(n,:), Coupling%visdfdi_double_call(n,:), ix, im, levs,                                                        &
+                   Model%daily_mean,                                                                                                                          &
+       !  ---  input/output:
+                   dtdt_double_call(n,:,:), dtdtc_double_call(n,:,:),                                                                                         &
+       !  ---  outputs:
+                   adjsfcdsw_double_call(n,:), adjsfcnsw_double_call(n,:), adjsfcdlw_double_call(n,:), adjsfculw_double_call(n,:),                            &
+                   xmu_double_call(n,:), xcosz_double_call(n,:),                                                                                              &
+                   adjnirbmu_double_call(n,:), adjnirdfu_double_call(n,:), adjvisbmu_double_call(n,:), adjvisdfu_double_call(n,:),                            &
+                   adjnirbmd_double_call(n,:), adjnirdfd_double_call(n,:), adjvisbmd_double_call(n,:), adjvisdfd_double_call(n,:)                             &
+                 )
+           enddo
         endif
 
 !
@@ -993,8 +995,8 @@ module module_physics_driver
         Diag%ulwsfc(:) = Diag%ulwsfc(:) +   adjsfculw(:)*dtf
 
         if (Model%do_radiation_double_call) then
-           Diag%dlwsfc_double_call(:) = Diag%dlwsfc_double_call(:) +   adjsfcdlw_double_call(:)*dtf
-           Diag%ulwsfc_double_call(:) = Diag%ulwsfc_double_call(:) +   adjsfculw_double_call(:)*dtf
+           Diag%dlwsfc_double_call(:,:) = Diag%dlwsfc_double_call(:,:) +   adjsfcdlw_double_call(:,:)*dtf
+           Diag%ulwsfc_double_call(:,:) = Diag%ulwsfc_double_call(:,:) +   adjsfculw_double_call(:,:)*dtf
         endif
 
         Diag%psmean(:) = Diag%psmean(:) + Statein%pgr(:)*dtf        ! mean surface pressure
@@ -1509,13 +1511,13 @@ module module_physics_driver
       endif
 
       if (Model%do_radiation_double_call) then
-         Diag%dlwsfci_double_call(:) = adjsfcdlw_double_call(:)
-         Diag%ulwsfci_double_call(:) = adjsfculw_double_call(:)
-         Diag%uswsfci_double_call(:) = adjsfcdsw_double_call(:) - adjsfcnsw_double_call(:)
-         Diag%dswsfci_double_call(:) = adjsfcdsw_double_call(:)
+         Diag%dlwsfci_double_call(:,:) = adjsfcdlw_double_call(:,:)
+         Diag%ulwsfci_double_call(:,:) = adjsfculw_double_call(:,:)
+         Diag%uswsfci_double_call(:,:) = adjsfcdsw_double_call(:,:) - adjsfcnsw_double_call(:,:)
+         Diag%dswsfci_double_call(:,:) = adjsfcdsw_double_call(:,:)
 
-         Diag%uswsfc_double_call(:) = Diag%uswsfc_double_call(:) + (adjsfcdsw_double_call(:) - adjsfcnsw_double_call(:))*dtf
-         Diag%dswsfc_double_call(:) = Diag%dswsfc_double_call(:) + adjsfcdsw_double_call(:)*dtf
+         Diag%uswsfc_double_call(:,:) = Diag%uswsfc_double_call(:,:) + (adjsfcdsw_double_call(:,:) - adjsfcnsw_double_call(:,:))*dtf
+         Diag%dswsfc_double_call(:,:) = Diag%dswsfc_double_call(:,:) + adjsfcdsw_double_call(:,:)*dtf
       endif
 
 !  --- ...  update near surface fields

--- a/GFS_layer/GFS_physics_driver.F90
+++ b/GFS_layer/GFS_physics_driver.F90
@@ -884,8 +884,8 @@ module module_physics_driver
              adjnirbmd, adjnirdfd, adjvisbmd, adjvisdfd                     &
            )
 
-        if (Model%do_radiation_double_call) then
-           call compute_radiation_double_call_diagnostics(                  &
+        if (Model%do_diagnostic_radiation_with_scaled_co2) then
+           call compute_diagnostics_with_scaled_co2(                        &
               Model, Statein, Sfcprop, Coupling, Grid, Radtend, ix, im,     &
               levs, Diag                                                    &
            )
@@ -4234,7 +4234,7 @@ module module_physics_driver
         delp = initial_mass_of_dry_air_plus_vapor * dry_air_plus_hydrometeor_mass_fraction_after_physics
       end subroutine compute_updated_delp_following_dynamics_definition
 
-  subroutine compute_radiation_double_call_diagnostics(Model, Statein, Sfcprop, Coupling, Grid, Radtend, ix, im, levs, Diag)
+  subroutine compute_diagnostics_with_scaled_co2(Model, Statein, Sfcprop, Coupling, Grid, Radtend, ix, im, levs, Diag)
      type(GFS_control_type),         intent(in)    :: Model
      type(GFS_statein_type),         intent(in)    :: Statein
      type(GFS_sfcprop_type),         intent(in)    :: Sfcprop
@@ -4252,38 +4252,38 @@ module module_physics_driver
         adjsfculw, adjnirbmu, adjnirdfu, adjvisbmu, adjvisdfu, adjnirbmd,    &
         adjnirdfd, adjvisbmd, adjvisdfd, xmu, xcosz
 
-     do n = 1, Model%n_radiation_double_calls
-        call dcyc2t3                                                                                                                                    &
+     do n = 1, Model%n_diagnostic_radiation_calls
+        call dcyc2t3                                                                                                                                                &
     !  ---  inputs:
-           ( Model%solhr, Model%slag, Model%sdec, Model%cdec, Grid%sinlat,                                                                              &
-             Grid%coslat, Grid%xlon, Radtend%coszen, Sfcprop%tsfc,                                                                                      &
-             Statein%tgrs(1,1), Radtend%tsflw, Radtend%semis,                                                                                           &
-             Coupling%sfcdsw_double_call(n,:), Coupling%sfcnsw_double_call(n,:), Coupling%sfcdlw_double_call(n,:),                                      &
-             Radtend%htrsw_double_call(n,:,:), Radtend%swhc_double_call(n,:,:), Radtend%htrlw_double_call(n,:,:), Radtend%lwhc_double_call(n,:,:),      &
-             Coupling%nirbmui_double_call(n,:), Coupling%nirdfui_double_call(n,:), Coupling%visbmui_double_call(n,:),                                   &
-             Coupling%visdfui_double_call(n,:), Coupling%nirbmdi_double_call(n,:), Coupling%nirdfdi_double_call(n,:),                                   &
-             Coupling%visbmdi_double_call(n,:), Coupling%visdfdi_double_call(n,:), ix, im, levs,                                                        &
-             Model%daily_mean,                                                                                                                          &
+           ( Model%solhr, Model%slag, Model%sdec, Model%cdec, Grid%sinlat,                                                                                          &
+             Grid%coslat, Grid%xlon, Radtend%coszen, Sfcprop%tsfc,                                                                                                  &
+             Statein%tgrs(1,1), Radtend%tsflw, Radtend%semis,                                                                                                       &
+             Coupling%sfcdsw_with_scaled_co2(n,:), Coupling%sfcnsw_with_scaled_co2(n,:), Coupling%sfcdlw_with_scaled_co2(n,:),                                      &
+             Radtend%htrsw_with_scaled_co2(n,:,:), Radtend%swhc_with_scaled_co2(n,:,:), Radtend%htrlw_with_scaled_co2(n,:,:), Radtend%lwhc_with_scaled_co2(n,:,:),  &
+             Coupling%nirbmui_with_scaled_co2(n,:), Coupling%nirdfui_with_scaled_co2(n,:), Coupling%visbmui_with_scaled_co2(n,:),                                   &
+             Coupling%visdfui_with_scaled_co2(n,:), Coupling%nirbmdi_with_scaled_co2(n,:), Coupling%nirdfdi_with_scaled_co2(n,:),                                   &
+             Coupling%visbmdi_with_scaled_co2(n,:), Coupling%visdfdi_with_scaled_co2(n,:), ix, im, levs,                                                            &
+             Model%daily_mean,                                                                                                                                      &
     !  ---  input/output:
-             dtdt, dtdtc,                                                                                                                               &
+             dtdt, dtdtc,                                                                                                                                           &
     !  ---  outputs:
-             adjsfcdsw, adjsfcnsw, adjsfcdlw, adjsfculw, xmu, xcosz, adjnirbmu, adjnirdfu, adjvisbmu, adjvisdfu, adjnirbmd, adjnirdfd, adjvisbmd,       &
-             adjvisdfd                                                                                                                                  &
+             adjsfcdsw, adjsfcnsw, adjsfcdlw, adjsfculw, xmu, xcosz, adjnirbmu, adjnirdfu, adjvisbmu, adjvisdfu, adjnirbmd, adjnirdfd, adjvisbmd,                   &
+             adjvisdfd                                                                                                                                              &
            )
 
-        Diag%dlwsfc_double_call(n,:) = Diag%dlwsfc_double_call(n,:) + adjsfcdlw * Model%dtf
-        Diag%ulwsfc_double_call(n,:) = Diag%ulwsfc_double_call(n,:) + adjsfculw * Model%dtf
+        Diag%dlwsfc_with_scaled_co2(n,:) = Diag%dlwsfc_with_scaled_co2(n,:) + adjsfcdlw * Model%dtf
+        Diag%ulwsfc_with_scaled_co2(n,:) = Diag%ulwsfc_with_scaled_co2(n,:) + adjsfculw * Model%dtf
 
-        Diag%dlwsfci_double_call(n,:) = adjsfcdlw
-        Diag%ulwsfci_double_call(n,:) = adjsfculw
-        Diag%uswsfci_double_call(n,:) = adjsfcdsw - adjsfcnsw
-        Diag%dswsfci_double_call(n,:) = adjsfcdsw
+        Diag%dlwsfci_with_scaled_co2(n,:) = adjsfcdlw
+        Diag%ulwsfci_with_scaled_co2(n,:) = adjsfculw
+        Diag%uswsfci_with_scaled_co2(n,:) = adjsfcdsw - adjsfcnsw
+        Diag%dswsfci_with_scaled_co2(n,:) = adjsfcdsw
 
-        Diag%uswsfc_double_call(n,:) = Diag%uswsfc_double_call(n,:) + (adjsfcdsw - adjsfcnsw) * Model%dtf
-        Diag%dswsfc_double_call(n,:) = Diag%dswsfc_double_call(n,:) + adjsfcdsw * Model%dtf
+        Diag%uswsfc_with_scaled_co2(n,:) = Diag%uswsfc_with_scaled_co2(n,:) + (adjsfcdsw - adjsfcnsw) * Model%dtf
+        Diag%dswsfc_with_scaled_co2(n,:) = Diag%dswsfc_with_scaled_co2(n,:) + adjsfcdsw * Model%dtf
       enddo
 
-  end subroutine compute_radiation_double_call_diagnostics
+  end subroutine compute_diagnostics_with_scaled_co2
 !> @}
 
 end module module_physics_driver

--- a/GFS_layer/GFS_physics_driver.F90
+++ b/GFS_layer/GFS_physics_driver.F90
@@ -4253,22 +4253,25 @@ module module_physics_driver
         adjnirdfd, adjvisbmd, adjvisdfd, xmu, xcosz
 
      do n = 1, Model%n_diagnostic_radiation_calls
-        call dcyc2t3                                                                                                                                                &
+        call dcyc2t3                                                                        &
     !  ---  inputs:
-           ( Model%solhr, Model%slag, Model%sdec, Model%cdec, Grid%sinlat,                                                                                          &
-             Grid%coslat, Grid%xlon, Radtend%coszen, Sfcprop%tsfc,                                                                                                  &
-             Statein%tgrs(1,1), Radtend%tsflw, Radtend%semis,                                                                                                       &
-             Coupling%sfcdsw_with_scaled_co2(n,:), Coupling%sfcnsw_with_scaled_co2(n,:), Coupling%sfcdlw_with_scaled_co2(n,:),                                      &
-             Radtend%htrsw_with_scaled_co2(n,:,:), Radtend%swhc_with_scaled_co2(n,:,:), Radtend%htrlw_with_scaled_co2(n,:,:), Radtend%lwhc_with_scaled_co2(n,:,:),  &
-             Coupling%nirbmui_with_scaled_co2(n,:), Coupling%nirdfui_with_scaled_co2(n,:), Coupling%visbmui_with_scaled_co2(n,:),                                   &
-             Coupling%visdfui_with_scaled_co2(n,:), Coupling%nirbmdi_with_scaled_co2(n,:), Coupling%nirdfdi_with_scaled_co2(n,:),                                   &
-             Coupling%visbmdi_with_scaled_co2(n,:), Coupling%visdfdi_with_scaled_co2(n,:), ix, im, levs,                                                            &
-             Model%daily_mean,                                                                                                                                      &
+           ( Model%solhr, Model%slag, Model%sdec, Model%cdec, Grid%sinlat,                  &
+             Grid%coslat, Grid%xlon, Radtend%coszen, Sfcprop%tsfc,                          &
+             Statein%tgrs(1,1), Radtend%tsflw, Radtend%semis,                               &
+             Coupling%sfcdsw_with_scaled_co2(n,:), Coupling%sfcnsw_with_scaled_co2(n,:),    &
+             Coupling%sfcdlw_with_scaled_co2(n,:), Radtend%htrsw_with_scaled_co2(n,:,:),    &
+             Radtend%swhc_with_scaled_co2(n,:,:), Radtend%htrlw_with_scaled_co2(n,:,:),     &
+             Radtend%lwhc_with_scaled_co2(n,:,:), Coupling%nirbmui_with_scaled_co2(n,:),    &
+             Coupling%nirdfui_with_scaled_co2(n,:), Coupling%visbmui_with_scaled_co2(n,:),  &
+             Coupling%visdfui_with_scaled_co2(n,:), Coupling%nirbmdi_with_scaled_co2(n,:),  &
+             Coupling%nirdfdi_with_scaled_co2(n,:), Coupling%visbmdi_with_scaled_co2(n,:),  &
+             Coupling%visdfdi_with_scaled_co2(n,:), ix, im, levs, Model%daily_mean,         &
     !  ---  input/output:
-             dtdt, dtdtc,                                                                                                                                           &
+             dtdt, dtdtc,                                                                   &
     !  ---  outputs:
-             adjsfcdsw, adjsfcnsw, adjsfcdlw, adjsfculw, xmu, xcosz, adjnirbmu, adjnirdfu, adjvisbmu, adjvisdfu, adjnirbmd, adjnirdfd, adjvisbmd,                   &
-             adjvisdfd                                                                                                                                              &
+             adjsfcdsw, adjsfcnsw, adjsfcdlw, adjsfculw, xmu, xcosz, adjnirbmu, adjnirdfu,  &
+             adjvisbmu, adjvisdfu, adjnirbmd, adjnirdfd, adjvisbmd,                         &
+             adjvisdfd                                                                      &
            )
 
         Diag%dlwsfc_with_scaled_co2(n,:) = Diag%dlwsfc_with_scaled_co2(n,:) + adjsfcdlw * Model%dtf

--- a/GFS_layer/GFS_physics_driver.F90
+++ b/GFS_layer/GFS_physics_driver.F90
@@ -473,7 +473,7 @@ module module_physics_driver
            tisfc_cice, tsea_cice, hice_cice, fice_cice,                 &
            !--- for CS-convection
            wcbmax
-
+           
       logical, dimension(size(Grid%xlon,1))                ::           &
            wet, dry,              icy
 !
@@ -947,7 +947,6 @@ module module_physics_driver
         ! use the adjsfcdlw_for_coupling pointer here.
         Diag%dlwsfc(:) = Diag%dlwsfc(:) +   adjsfcdlw(:)*dtf
         Diag%ulwsfc(:) = Diag%ulwsfc(:) +   adjsfculw(:)*dtf
-
         Diag%psmean(:) = Diag%psmean(:) + Statein%pgr(:)*dtf        ! mean surface pressure
 
         if (Model%override_surface_radiative_fluxes) then

--- a/GFS_layer/GFS_radiation_driver.F90
+++ b/GFS_layer/GFS_radiation_driver.F90
@@ -1229,7 +1229,6 @@
 
       !--- TYPED VARIABLES
       type (cmpfsw_type),    dimension(size(Grid%xlon,1)) :: scmpsw
-
 !
 !===> ...  begin here
 !only call GFS_radiation_driver at radiation time step
@@ -1932,7 +1931,6 @@
               Diag%fluxr(i,32) = Diag%fluxr(i,32) + Radtend%sfcfsw(i)%dnfx0 * tem0d  ! clear sky sfc sw dn
             endif
           enddo
-
         endif
 
 !  ---  save total and boundary layer clouds

--- a/GFS_layer/GFS_radiation_driver.F90
+++ b/GFS_layer/GFS_radiation_driver.F90
@@ -1391,7 +1391,7 @@
 
       if (Model%do_diagnostic_radiation_with_scaled_co2) then
          do n = 1, Model%n_diagnostic_radiation_calls
-            Diag%column_moles_co2_per_square_meter_with_scaled_co2(n,:) = Model%diagnostic_radiation_call_co2_scale_factors(n) * Diag%column_moles_co2_per_square_meter
+            Diag%column_moles_co2_per_square_meter_with_scaled_co2(n,:) = Model%diagnostic_radiation_co2_scale_factors(n) * Diag%column_moles_co2_per_square_meter
          enddo
       endif
 
@@ -2019,7 +2019,7 @@
 
             do n = 1, Model%n_diagnostic_radiation_calls
               gasvmr_with_scaled_co2 = gasvmr
-              gasvmr_with_scaled_co2(:,:,1) = Model%diagnostic_radiation_call_co2_scale_factors(n) * gasvmr(:,:,1)
+              gasvmr_with_scaled_co2(:,:,1) = Model%diagnostic_radiation_co2_scale_factors(n) * gasvmr(:,:,1)
 
               if (Model%swhtr) then
                 call swrad (plyr, plvl, tlyr, tlvl, qlyr, olyr,                                                                &    !  ---  inputs
@@ -2138,7 +2138,7 @@
 
          do n = 1, Model%n_diagnostic_radiation_calls
             gasvmr_with_scaled_co2 = gasvmr
-            gasvmr_with_scaled_co2(:,:,1) = Model%diagnostic_radiation_call_co2_scale_factors(n) * gasvmr(:,:,1)
+            gasvmr_with_scaled_co2(:,:,1) = Model%diagnostic_radiation_co2_scale_factors(n) * gasvmr(:,:,1)
 
             if (Model%lwhtr) then
                call lwrad (plyr, plvl, tlyr, tlvl, qlyr, olyr, gasvmr_with_scaled_co2,                                &     !  ---  inputs

--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -347,14 +347,14 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: visbmui(:)     => null()   !< sfc uv+vis beam sw upward flux (w/m2)
     real (kind=kind_phys), pointer :: visdfui(:)     => null()   !< sfc uv+vis diff sw upward flux (w/m2)
 
-    real (kind=kind_phys), pointer :: nirbmdi_double_call(:,:)     => null()   !< sfc nir beam sw downward flux with scaled carbon dioxide (w/m2)
-    real (kind=kind_phys), pointer :: nirdfdi_double_call(:,:)     => null()   !< sfc nir diff sw downward flux with scaled carbon dioxide (w/m2)
-    real (kind=kind_phys), pointer :: visbmdi_double_call(:,:)     => null()   !< sfc uv+vis beam sw downward flux with scaled carbon dioxide (w/m2)
-    real (kind=kind_phys), pointer :: visdfdi_double_call(:,:)     => null()   !< sfc uv+vis diff sw downward flux with scaled carbon dioxide (w/m2)
-    real (kind=kind_phys), pointer :: nirbmui_double_call(:,:)     => null()   !< sfc nir beam sw upward flux with scaled carbon dioxide (w/m2)
-    real (kind=kind_phys), pointer :: nirdfui_double_call(:,:)     => null()   !< sfc nir diff sw upward flux with scaled carbon dioxide (w/m2)
-    real (kind=kind_phys), pointer :: visbmui_double_call(:,:)     => null()   !< sfc uv+vis beam sw upward flux with scaled carbon dioxide (w/m2)
-    real (kind=kind_phys), pointer :: visdfui_double_call(:,:)     => null()   !< sfc uv+vis diff sw upward flux with scaled carbon dioxide (w/m2)
+    real (kind=kind_phys), pointer :: nirbmdi_with_scaled_co2(:,:)     => null()   !< sfc nir beam sw downward flux with scaled carbon dioxide (w/m2)
+    real (kind=kind_phys), pointer :: nirdfdi_with_scaled_co2(:,:)     => null()   !< sfc nir diff sw downward flux with scaled carbon dioxide (w/m2)
+    real (kind=kind_phys), pointer :: visbmdi_with_scaled_co2(:,:)     => null()   !< sfc uv+vis beam sw downward flux with scaled carbon dioxide (w/m2)
+    real (kind=kind_phys), pointer :: visdfdi_with_scaled_co2(:,:)     => null()   !< sfc uv+vis diff sw downward flux with scaled carbon dioxide (w/m2)
+    real (kind=kind_phys), pointer :: nirbmui_with_scaled_co2(:,:)     => null()   !< sfc nir beam sw upward flux with scaled carbon dioxide (w/m2)
+    real (kind=kind_phys), pointer :: nirdfui_with_scaled_co2(:,:)     => null()   !< sfc nir diff sw upward flux with scaled carbon dioxide (w/m2)
+    real (kind=kind_phys), pointer :: visbmui_with_scaled_co2(:,:)     => null()   !< sfc uv+vis beam sw upward flux with scaled carbon dioxide (w/m2)
+    real (kind=kind_phys), pointer :: visdfui_with_scaled_co2(:,:)     => null()   !< sfc uv+vis diff sw upward flux with scaled carbon dioxide (w/m2)
 
     !--- In (physics only)
     real (kind=kind_phys), pointer :: sfcdsw(:)      => null()   !< total sky sfc downward sw flux ( w/m**2 )
@@ -364,11 +364,11 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: sfcdlw(:)      => null()   !< total sky sfc downward lw flux ( w/m**2 )
                                                                  !< GFS_radtend_type%sfclsw%dnfxc
 
-    real (kind=kind_phys), pointer :: sfcdsw_double_call(:,:)      => null()   !< total sky sfc downward sw flux with scaled carbon dioxide ( w/m**2 )
+    real (kind=kind_phys), pointer :: sfcdsw_with_scaled_co2(:,:)      => null()   !< total sky sfc downward sw flux with scaled carbon dioxide ( w/m**2 )
                                                                  !< GFS_radtend_type%sfcfsw%dnfxc
-    real (kind=kind_phys), pointer :: sfcnsw_double_call(:,:)      => null()   !< total sky sfc netsw flx into ground with scaled carbon dioxide(w/m**2)
+    real (kind=kind_phys), pointer :: sfcnsw_with_scaled_co2(:,:)      => null()   !< total sky sfc netsw flx into ground with scaled carbon dioxide(w/m**2)
                                                                  !< difference of dnfxc & upfxc from GFS_radtend_type%sfcfsw
-    real (kind=kind_phys), pointer :: sfcdlw_double_call(:,:)      => null()   !< total sky sfc downward lw flux with scaled carbon dioxide ( w/m**2 )
+    real (kind=kind_phys), pointer :: sfcdlw_with_scaled_co2(:,:)      => null()   !< total sky sfc downward lw flux with scaled carbon dioxide ( w/m**2 )
                                                                  !< GFS_radtend_type%sfclsw%dnfxc
 
     !--- incoming quantities
@@ -570,9 +570,9 @@ module GFS_typedefs
     logical              :: fixed_solhr     !< flag to fix solar angle to initial time
     logical              :: fixed_sollat    !< flag to fix solar latitude
     logical              :: daily_mean      !< flag to replace cosz with daily mean value
-    logical              :: do_radiation_double_call !< flag to call radiation a second time with scaled carbon dioxide
-    real(kind=kind_phys), dimension(8) :: radiation_double_call_co2_scale_factors !< factors to scale carbon dioxide by in radiation double calls
-    integer              :: n_radiation_double_calls  !< number of radiation double calls
+    logical              :: do_diagnostic_radiation_with_scaled_co2 !< flag to call radiation multiple times with scaled carbon dioxide for diagnostic purposes (does not affect evolution of simulation)
+    real(kind=kind_phys), dimension(8) :: diagnostic_radiation_call_co2_scale_factors !< factors to scale carbon dioxide by in diagnostic radiation calls
+    integer              :: n_diagnostic_radiation_calls  !< number of diagnostic radiation calls
 
     !--- microphysical switch
     integer              :: ncld            !< cnoice of cloud scheme
@@ -1053,7 +1053,7 @@ module GFS_typedefs
 !-----------------------------------------
 ! Optional arrays for outputs when calling the radiation code a second time with scaled carbon dioxide
 
-    type (sfcfsw_type),    pointer :: sfcfsw_double_call(:,:)   => null()   !< sw radiation fluxes at sfc with scaled carbon dioxide
+    type (sfcfsw_type),    pointer :: sfcfsw_with_scaled_co2(:,:)   => null()   !< sw radiation fluxes at sfc with scaled carbon dioxide
                                                                             !< [dim(im): created in grrad.f], components:
                                                                             !!     (check module_radsw_parameters for definition)
                                                                             !!\n   %upfxc - total sky upward sw flux at sfc (w/m**2)
@@ -1061,7 +1061,7 @@ module GFS_typedefs
                                                                             !!\n   %dnfxc - total sky downward sw flux at sfc (w/m**2)
                                                                             !!\n   %dnfx0 - clear sky downward sw flux at sfc (w/m**2)
 
-    type (sfcflw_type),    pointer :: sfcflw_double_call(:,:)    => null()  !< lw radiation fluxes at sfc with scaled carbon dioxide
+    type (sfcflw_type),    pointer :: sfcflw_with_scaled_co2(:,:)    => null()  !< lw radiation fluxes at sfc with scaled carbon dioxide
                                                                             !< [dim(im): created in grrad.f], components:
                                                                             !!     (check module_radlw_paramters for definition)
                                                                             !!\n   %upfxc - total sky upward lw flux at sfc (w/m**2)
@@ -1069,12 +1069,12 @@ module GFS_typedefs
                                                                             !!\n   %dnfxc - total sky downward lw flux at sfc (w/m**2)
                                                                             !!\n   %dnfx0 - clear sky downward lw flux at sfc (w/m**2)
 
-    real (kind=kind_phys), pointer :: htrsw_double_call (:,:,:)  => null()  !< swh  total sky sw heating rate in k/sec with scaled carbon dioxide
-    real (kind=kind_phys), pointer :: htrlw_double_call (:,:,:)  => null()  !< hlw  total sky lw heating rate in k/sec with scaled carbon dioxide
+    real (kind=kind_phys), pointer :: htrsw_with_scaled_co2 (:,:,:)  => null()  !< swh  total sky sw heating rate in k/sec with scaled carbon dioxide
+    real (kind=kind_phys), pointer :: htrlw_with_scaled_co2 (:,:,:)  => null()  !< hlw  total sky lw heating rate in k/sec with scaled carbon dioxide
 
-    real (kind=kind_phys), pointer :: swhc_double_call (:,:,:)   => null()  !< clear sky sw heating rates with scaled carbon dioxide ( k/s )
-    real (kind=kind_phys), pointer :: lwhc_double_call (:,:,:)   => null()  !< clear sky lw heating rates with scaled carbon dioxide ( k/s )
-    real (kind=kind_phys), pointer :: lwhd_double_call (:,:,:,:) => null()  !< idea sky lw heating rates with scaled carbon dioxide ( k/s )
+    real (kind=kind_phys), pointer :: swhc_with_scaled_co2 (:,:,:)   => null()  !< clear sky sw heating rates with scaled carbon dioxide ( k/s )
+    real (kind=kind_phys), pointer :: lwhc_with_scaled_co2 (:,:,:)   => null()  !< clear sky lw heating rates with scaled carbon dioxide ( k/s )
+    real (kind=kind_phys), pointer :: lwhd_with_scaled_co2 (:,:,:,:) => null()  !< idea sky lw heating rates with scaled carbon dioxide ( k/s )
 
     contains
       procedure :: create  => radtend_create   !<   allocate array data
@@ -1227,25 +1227,25 @@ module GFS_typedefs
     type (topflw_type),    pointer :: topflw(:)     => null()   !< lw radiation fluxes at top, component:
                                                !       %upfxc    - total sky upward lw flux at toa (w/m**2)
                                                !       %upfx0    - clear sky upward lw flux at toa (w/m**2)
-    type (topfsw_type),    pointer :: topfsw_double_call(:,:)     => null()   !< sw radiation fluxes at toa with scaled carbon dioxide, components:
+    type (topfsw_type),    pointer :: topfsw_with_scaled_co2(:,:)     => null()   !< sw radiation fluxes at toa with scaled carbon dioxide, components:
                                                              !       %upfxc    - total sky upward sw flux at toa (w/m**2)
                                                              !       %dnfxc    - total sky downward sw flux at toa (w/m**2)
                                                              !       %upfx0    - clear sky upward sw flux at toa (w/m**2)
-    type (topflw_type),    pointer :: topflw_double_call(:,:)     => null()   !< lw radiation fluxes at top with scaled carbon dioxide, component:
+    type (topflw_type),    pointer :: topflw_with_scaled_co2(:,:)     => null()   !< lw radiation fluxes at top with scaled carbon dioxide, component:
                                                              !       %upfxc    - total sky upward lw flux at toa (w/m**2)
                                                              !       %upfx0    - clear sky upward lw flux at toa (w/m**2)
-    real (kind=kind_phys), pointer :: dswrftoa_double_call(:,:) => null()  !< sw dn at toa with scaled carbon dioxide (w/m**2)
-    real (kind=kind_phys), pointer :: uswrftoa_double_call(:,:) => null()  !< sw up at toa with scaled carbon dioxide (w/m**2)
-    real (kind=kind_phys), pointer :: ulwrftoa_double_call(:,:) => null()  !< lw up at toa with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: dswrftoa_with_scaled_co2(:,:) => null()  !< sw dn at toa with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: uswrftoa_with_scaled_co2(:,:) => null()  !< sw up at toa with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: ulwrftoa_with_scaled_co2(:,:) => null()  !< lw up at toa with scaled carbon dioxide (w/m**2)
 
-    real (kind=kind_phys), pointer :: dlwsfci_double_call(:,:) => null()   !< instantaneous lw dn at sfc with scaled carbon dioxide (w/m**2)
-    real (kind=kind_phys), pointer :: ulwsfci_double_call(:,:) => null()   !< instantaneous lw up at sfc with scaled carbon dioxide (w/m**2)
-    real (kind=kind_phys), pointer :: dswsfci_double_call(:,:) => null()   !< instantaneous sw dn at sfc with scaled carbon dioxide (w/m**2)
-    real (kind=kind_phys), pointer :: uswsfci_double_call(:,:) => null()   !< instantaneous sw up at sfc with scaled carbon dioxide (w/m**2)
-    real (kind=kind_phys), pointer :: dlwsfc_double_call(:,:) => null()    !< interval-average lw dn at sfc with scaled carbon dioxide (w/m**2)
-    real (kind=kind_phys), pointer :: ulwsfc_double_call(:,:) => null()    !< interval-average lw up at sfc with scaled carbon dioxide (w/m**2)
-    real (kind=kind_phys), pointer :: dswsfc_double_call(:,:) => null()    !< interval-average sw dn at sfc with scaled carbon dioxide (w/m**2)
-    real (kind=kind_phys), pointer :: uswsfc_double_call(:,:) => null()    !< interval-average sw up at sfc with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: dlwsfci_with_scaled_co2(:,:) => null()   !< instantaneous lw dn at sfc with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: ulwsfci_with_scaled_co2(:,:) => null()   !< instantaneous lw up at sfc with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: dswsfci_with_scaled_co2(:,:) => null()   !< instantaneous sw dn at sfc with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: uswsfci_with_scaled_co2(:,:) => null()   !< instantaneous sw up at sfc with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: dlwsfc_with_scaled_co2(:,:) => null()    !< interval-average lw dn at sfc with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: ulwsfc_with_scaled_co2(:,:) => null()    !< interval-average lw up at sfc with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: dswsfc_with_scaled_co2(:,:) => null()    !< interval-average sw dn at sfc with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: uswsfc_with_scaled_co2(:,:) => null()    !< interval-average sw up at sfc with scaled carbon dioxide (w/m**2)
 
 #if defined (USE_COSP) || defined (COSP_OFFLINE)
     type (cosp_type)               :: cosp                      !< cosp output
@@ -1390,7 +1390,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: co2(:,:) => null()  ! Vertically resolved CO2 concentration
     real (kind=kind_phys), pointer :: column_moles_co2_per_square_meter(:) => null()  ! Moles of CO2 in column per square meter
     real (kind=kind_phys), pointer :: column_moles_dry_air_per_square_meter(:) => null()  ! Moles of dry air in column per square meter
-    real (kind=kind_phys), pointer :: column_moles_co2_per_square_meter_radiation_double_call(:,:) => null()  ! Moles of CO2 in column per square meter in radiation double call
+    real (kind=kind_phys), pointer :: column_moles_co2_per_square_meter_with_scaled_co2(:,:) => null()  ! Moles of CO2 in column per square meter in radiation double call
 
     !--- accumulated quantities for 3D diagnostics
     real (kind=kind_phys), pointer :: upd_mf (:,:)   => null()  !< instantaneous convective updraft mass flux
@@ -1925,32 +1925,32 @@ module GFS_typedefs
     Coupling%sfcnsw    = clear_val
     Coupling%sfcdlw    = clear_val
 
-    if (Model%do_radiation_double_call) then
-       allocate (Coupling%nirbmdi_double_call  (Model%n_radiation_double_calls,IM))
-       allocate (Coupling%nirdfdi_double_call  (Model%n_radiation_double_calls,IM))
-       allocate (Coupling%visbmdi_double_call  (Model%n_radiation_double_calls,IM))
-       allocate (Coupling%visdfdi_double_call  (Model%n_radiation_double_calls,IM))
-       allocate (Coupling%nirbmui_double_call  (Model%n_radiation_double_calls,IM))
-       allocate (Coupling%nirdfui_double_call  (Model%n_radiation_double_calls,IM))
-       allocate (Coupling%visbmui_double_call  (Model%n_radiation_double_calls,IM))
-       allocate (Coupling%visdfui_double_call  (Model%n_radiation_double_calls,IM))
+    if (Model%do_diagnostic_radiation_with_scaled_co2) then
+       allocate (Coupling%nirbmdi_with_scaled_co2  (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Coupling%nirdfdi_with_scaled_co2  (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Coupling%visbmdi_with_scaled_co2  (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Coupling%visdfdi_with_scaled_co2  (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Coupling%nirbmui_with_scaled_co2  (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Coupling%nirdfui_with_scaled_co2  (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Coupling%visbmui_with_scaled_co2  (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Coupling%visdfui_with_scaled_co2  (Model%n_diagnostic_radiation_calls,IM))
 
-       Coupling%nirbmdi_double_call = clear_val
-       Coupling%nirdfdi_double_call = clear_val
-       Coupling%visbmdi_double_call = clear_val
-       Coupling%visdfdi_double_call = clear_val
-       Coupling%nirbmui_double_call = clear_val
-       Coupling%nirdfui_double_call = clear_val
-       Coupling%visbmui_double_call = clear_val
-       Coupling%visdfui_double_call = clear_val
+       Coupling%nirbmdi_with_scaled_co2 = clear_val
+       Coupling%nirdfdi_with_scaled_co2 = clear_val
+       Coupling%visbmdi_with_scaled_co2 = clear_val
+       Coupling%visdfdi_with_scaled_co2 = clear_val
+       Coupling%nirbmui_with_scaled_co2 = clear_val
+       Coupling%nirdfui_with_scaled_co2 = clear_val
+       Coupling%visbmui_with_scaled_co2 = clear_val
+       Coupling%visdfui_with_scaled_co2 = clear_val
 
-       allocate (Coupling%sfcdsw_double_call    (Model%n_radiation_double_calls,IM))
-       allocate (Coupling%sfcnsw_double_call    (Model%n_radiation_double_calls,IM))
-       allocate (Coupling%sfcdlw_double_call    (Model%n_radiation_double_calls,IM))
+       allocate (Coupling%sfcdsw_with_scaled_co2    (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Coupling%sfcnsw_with_scaled_co2    (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Coupling%sfcdlw_with_scaled_co2    (Model%n_diagnostic_radiation_calls,IM))
 
-       Coupling%sfcdsw_double_call    = clear_val
-       Coupling%sfcnsw_double_call    = clear_val
-       Coupling%sfcdlw_double_call    = clear_val
+       Coupling%sfcdsw_with_scaled_co2    = clear_val
+       Coupling%sfcnsw_with_scaled_co2    = clear_val
+       Coupling%sfcdlw_with_scaled_co2    = clear_val
     endif
 
     if (Model%cplflx .or. Model%do_sppt) then
@@ -2281,8 +2281,8 @@ end subroutine overrides_create
     logical              :: fixed_solhr    = .false.         !< flag to fix solar angle to initial time
     logical              :: fixed_sollat   = .false.         !< flag to fix solar latitude
     logical              :: daily_mean     = .false.         !< flag to replace cosz with daily mean value
-    logical              :: do_radiation_double_call = .false.  !< flag to call radiation a second time with scaled carbon dioxide
-    real(kind=kind_phys), dimension(8) :: radiation_double_call_co2_scale_factors = -999.0  !< factors to scale carbon dioxide by in radiation double calls
+    logical              :: do_diagnostic_radiation_with_scaled_co2 = .false.  !< flag to call radiation a second time with scaled carbon dioxide
+    real(kind=kind_phys), dimension(8) :: diagnostic_radiation_call_co2_scale_factors = -999.0  !< factors to scale carbon dioxide by in radiation double calls
 
     !--- GFDL microphysical parameters
     logical              :: do_sat_adj   = .false.           !< flag for fast saturation adjustment
@@ -2573,8 +2573,8 @@ end subroutine overrides_create
                                isot, iems,  iaer, iovr_sw, iovr_lw, ictm, isubc_sw,         &
                                isubc_lw, crick_proof, ccnorm, lwhtr, swhtr, nkld,           &
                                fixed_date, fixed_solhr, fixed_sollat, daily_mean, sollat,   &
-                               do_radiation_double_call,                                    &
-                               radiation_double_call_co2_scale_factors,                     &
+                               do_diagnostic_radiation_with_scaled_co2,                                    &
+                               diagnostic_radiation_call_co2_scale_factors,                     &
                           !--- microphysical parameterizations
                                ncld, do_sat_adj, zhao_mic, psautco, prautco,                &
                                evpco, wminco, fprcp, mg_dcs, mg_qcvar,                      &
@@ -2752,9 +2752,9 @@ end subroutine overrides_create
     Model%fixed_solhr      = fixed_solhr
     Model%fixed_sollat     = fixed_sollat
     Model%daily_mean       = daily_mean
-    Model%do_radiation_double_call = do_radiation_double_call
-    Model%radiation_double_call_co2_scale_factors = radiation_double_call_co2_scale_factors
-    Model%n_radiation_double_calls = count(Model%radiation_double_call_co2_scale_factors .ne. -999.0)
+    Model%do_diagnostic_radiation_with_scaled_co2 = do_diagnostic_radiation_with_scaled_co2
+    Model%diagnostic_radiation_call_co2_scale_factors = diagnostic_radiation_call_co2_scale_factors
+    Model%n_diagnostic_radiation_calls = count(Model%diagnostic_radiation_call_co2_scale_factors .ne. -999.0)
 
     !--- microphysical switch
     Model%ncld             = ncld
@@ -3454,9 +3454,9 @@ end subroutine overrides_create
       print *, ' fixed_solhr       : ', Model%fixed_solhr
       print *, ' fixed_sollat      : ', Model%fixed_sollat
       print *, ' daily_mean        : ', Model%daily_mean
-      print *, ' do_radiation_double_call : ', Model%do_radiation_double_call
-      print *, ' radiation_double_call_co2_scale_factors : ', Model%radiation_double_call_co2_scale_factors
-      print *, ' n_radiation_double_calls : ', Model%n_radiation_double_calls
+      print *, ' do_diagnostic_radiation_with_scaled_co2 : ', Model%do_diagnostic_radiation_with_scaled_co2
+      print *, ' diagnostic_radiation_call_co2_scale_factors : ', Model%diagnostic_radiation_call_co2_scale_factors
+      print *, ' n_diagnostic_radiation_calls : ', Model%n_diagnostic_radiation_calls
       print *, ' '
       print *, 'microphysical switch'
       print *, ' ncld              : ', Model%ncld
@@ -3896,32 +3896,32 @@ end subroutine overrides_create
     Radtend%lwhc  = clear_val
     Radtend%swhc  = clear_val
 
-    if (Model%do_radiation_double_call) then
-       allocate (Radtend%sfcfsw_double_call (Model%n_radiation_double_calls,IM))
-       allocate (Radtend%sfcflw_double_call (Model%n_radiation_double_calls,IM))
+    if (Model%do_diagnostic_radiation_with_scaled_co2) then
+       allocate (Radtend%sfcfsw_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Radtend%sfcflw_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM))
 
-       Radtend%sfcfsw_double_call%upfxc = clear_val
-       Radtend%sfcfsw_double_call%upfx0 = clear_val
-       Radtend%sfcfsw_double_call%dnfxc = clear_val
-       Radtend%sfcfsw_double_call%dnfx0 = clear_val
-       Radtend%sfcflw_double_call%upfxc = clear_val
-       Radtend%sfcflw_double_call%upfx0 = clear_val
-       Radtend%sfcflw_double_call%dnfxc = clear_val
-       Radtend%sfcflw_double_call%dnfx0 = clear_val
+       Radtend%sfcfsw_with_scaled_co2%upfxc = clear_val
+       Radtend%sfcfsw_with_scaled_co2%upfx0 = clear_val
+       Radtend%sfcfsw_with_scaled_co2%dnfxc = clear_val
+       Radtend%sfcfsw_with_scaled_co2%dnfx0 = clear_val
+       Radtend%sfcflw_with_scaled_co2%upfxc = clear_val
+       Radtend%sfcflw_with_scaled_co2%upfx0 = clear_val
+       Radtend%sfcflw_with_scaled_co2%dnfxc = clear_val
+       Radtend%sfcflw_with_scaled_co2%dnfx0 = clear_val
 
-       allocate(Radtend%htrsw_double_call(Model%n_radiation_double_calls,IM,Model%levs))
-       allocate(Radtend%htrlw_double_call(Model%n_radiation_double_calls,IM,Model%levs))
+       allocate(Radtend%htrsw_with_scaled_co2(Model%n_diagnostic_radiation_calls,IM,Model%levs))
+       allocate(Radtend%htrlw_with_scaled_co2(Model%n_diagnostic_radiation_calls,IM,Model%levs))
 
-       Radtend%htrsw_double_call  = clear_val
-       Radtend%htrlw_double_call  = clear_val
+       Radtend%htrsw_with_scaled_co2  = clear_val
+       Radtend%htrlw_with_scaled_co2  = clear_val
 
-       allocate (Radtend%swhc_double_call  (Model%n_radiation_double_calls,IM,Model%levs))
-       allocate (Radtend%lwhc_double_call  (Model%n_radiation_double_calls,IM,Model%levs))
-       allocate (Radtend%lwhd_double_call  (Model%n_radiation_double_calls,IM,Model%levs,6))
+       allocate (Radtend%swhc_with_scaled_co2  (Model%n_diagnostic_radiation_calls,IM,Model%levs))
+       allocate (Radtend%lwhc_with_scaled_co2  (Model%n_diagnostic_radiation_calls,IM,Model%levs))
+       allocate (Radtend%lwhd_with_scaled_co2  (Model%n_diagnostic_radiation_calls,IM,Model%levs,6))
 
-       Radtend%lwhd_double_call  = clear_val
-       Radtend%lwhc_double_call  = clear_val
-       Radtend%swhc_double_call  = clear_val
+       Radtend%lwhd_with_scaled_co2  = clear_val
+       Radtend%lwhc_with_scaled_co2  = clear_val
+       Radtend%swhc_with_scaled_co2  = clear_val
     endif
 
   end subroutine radtend_create
@@ -3942,20 +3942,20 @@ end subroutine overrides_create
     allocate (Diag%ctau    (IM,Model%levs,2))
     allocate (Diag%topfsw  (IM))
     allocate (Diag%topflw  (IM))
-    if (Model%do_radiation_double_call) then
-       allocate (Diag%topfsw_double_call  (Model%n_radiation_double_calls,IM))
-       allocate (Diag%topflw_double_call  (Model%n_radiation_double_calls,IM))
-       allocate (Diag%dswrftoa_double_call (Model%n_radiation_double_calls,IM))
-       allocate (Diag%uswrftoa_double_call (Model%n_radiation_double_calls,IM))
-       allocate (Diag%ulwrftoa_double_call (Model%n_radiation_double_calls,IM))
-       allocate (Diag%dlwsfci_double_call (Model%n_radiation_double_calls,IM))
-       allocate (Diag%ulwsfci_double_call (Model%n_radiation_double_calls,IM))
-       allocate (Diag%dswsfci_double_call (Model%n_radiation_double_calls,IM))
-       allocate (Diag%uswsfci_double_call (Model%n_radiation_double_calls,IM))
-       allocate (Diag%dlwsfc_double_call (Model%n_radiation_double_calls,IM))
-       allocate (Diag%ulwsfc_double_call (Model%n_radiation_double_calls,IM))
-       allocate (Diag%dswsfc_double_call (Model%n_radiation_double_calls,IM))
-       allocate (Diag%uswsfc_double_call (Model%n_radiation_double_calls,IM))
+    if (Model%do_diagnostic_radiation_with_scaled_co2) then
+       allocate (Diag%topfsw_with_scaled_co2  (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Diag%topflw_with_scaled_co2  (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Diag%dswrftoa_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Diag%uswrftoa_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Diag%ulwrftoa_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Diag%dlwsfci_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Diag%ulwsfci_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Diag%dswsfci_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Diag%uswsfci_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Diag%dlwsfc_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Diag%ulwsfc_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Diag%dswsfc_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Diag%uswsfc_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM))
     endif
     !--- Physics
     !--- In/Out
@@ -4085,8 +4085,8 @@ end subroutine overrides_create
       allocate (Diag%column_moles_co2_per_square_meter(IM))
       allocate (Diag%column_moles_dry_air_per_square_meter(IM))
 
-      if (Model%do_radiation_double_call) then
-         allocate (Diag%column_moles_co2_per_square_meter_radiation_double_call(Model%n_radiation_double_calls,IM))
+      if (Model%do_diagnostic_radiation_with_scaled_co2) then
+         allocate (Diag%column_moles_co2_per_square_meter_with_scaled_co2(Model%n_diagnostic_radiation_calls,IM))
       endif
 
       !--- needed to allocate GoCart coupling fields
@@ -4242,23 +4242,23 @@ end subroutine overrides_create
       Diag%cldcov     = zero
     endif
 
-    if (Model%do_radiation_double_call) then
-       Diag%topfsw_double_call%upfxc = zero
-       Diag%topfsw_double_call%dnfxc = zero
-       Diag%topfsw_double_call%upfx0 = zero
-       Diag%topflw_double_call%upfxc = zero
-       Diag%topflw_double_call%upfx0 = zero
-       Diag%dswrftoa_double_call = zero
-       Diag%uswrftoa_double_call = zero
-       Diag%ulwrftoa_double_call = zero
-       Diag%dlwsfci_double_call = zero
-       Diag%ulwsfci_double_call = zero
-       Diag%dswsfci_double_call = zero
-       Diag%uswsfci_double_call = zero
-       Diag%dlwsfc_double_call = zero
-       Diag%ulwsfc_double_call = zero
-       Diag%dswsfc_double_call = zero
-       Diag%uswsfc_double_call = zero
+    if (Model%do_diagnostic_radiation_with_scaled_co2) then
+       Diag%topfsw_with_scaled_co2%upfxc = zero
+       Diag%topfsw_with_scaled_co2%dnfxc = zero
+       Diag%topfsw_with_scaled_co2%upfx0 = zero
+       Diag%topflw_with_scaled_co2%upfxc = zero
+       Diag%topflw_with_scaled_co2%upfx0 = zero
+       Diag%dswrftoa_with_scaled_co2 = zero
+       Diag%uswrftoa_with_scaled_co2 = zero
+       Diag%ulwrftoa_with_scaled_co2 = zero
+       Diag%dlwsfci_with_scaled_co2 = zero
+       Diag%ulwsfci_with_scaled_co2 = zero
+       Diag%dswsfci_with_scaled_co2 = zero
+       Diag%uswsfci_with_scaled_co2 = zero
+       Diag%dlwsfc_with_scaled_co2 = zero
+       Diag%ulwsfc_with_scaled_co2 = zero
+       Diag%dswsfc_with_scaled_co2 = zero
+       Diag%uswsfc_with_scaled_co2 = zero
     endif
 
   end subroutine diag_rad_zero

--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -571,7 +571,7 @@ module GFS_typedefs
     logical              :: fixed_sollat    !< flag to fix solar latitude
     logical              :: daily_mean      !< flag to replace cosz with daily mean value
     logical              :: do_diagnostic_radiation_with_scaled_co2 !< flag to call radiation multiple times with scaled carbon dioxide for diagnostic purposes (does not affect evolution of simulation)
-    real(kind=kind_phys), dimension(8) :: diagnostic_radiation_call_co2_scale_factors !< factors to scale carbon dioxide by in diagnostic radiation calls
+    real(kind=kind_phys), dimension(8) :: diagnostic_radiation_co2_scale_factors !< factors to scale carbon dioxide by in diagnostic radiation calls
     integer              :: n_diagnostic_radiation_calls  !< number of diagnostic radiation calls
 
     !--- microphysical switch
@@ -2282,7 +2282,7 @@ end subroutine overrides_create
     logical              :: fixed_sollat   = .false.         !< flag to fix solar latitude
     logical              :: daily_mean     = .false.         !< flag to replace cosz with daily mean value
     logical              :: do_diagnostic_radiation_with_scaled_co2 = .false.  !< flag to call radiation a second time with scaled carbon dioxide
-    real(kind=kind_phys), dimension(8) :: diagnostic_radiation_call_co2_scale_factors = -999.0  !< factors to scale carbon dioxide by in radiation double calls
+    real(kind=kind_phys), dimension(8) :: diagnostic_radiation_co2_scale_factors = -999.0  !< factors to scale carbon dioxide by in radiation double calls
 
     !--- GFDL microphysical parameters
     logical              :: do_sat_adj   = .false.           !< flag for fast saturation adjustment
@@ -2574,7 +2574,7 @@ end subroutine overrides_create
                                isubc_lw, crick_proof, ccnorm, lwhtr, swhtr, nkld,           &
                                fixed_date, fixed_solhr, fixed_sollat, daily_mean, sollat,   &
                                do_diagnostic_radiation_with_scaled_co2,                                    &
-                               diagnostic_radiation_call_co2_scale_factors,                     &
+                               diagnostic_radiation_co2_scale_factors,                     &
                           !--- microphysical parameterizations
                                ncld, do_sat_adj, zhao_mic, psautco, prautco,                &
                                evpco, wminco, fprcp, mg_dcs, mg_qcvar,                      &
@@ -2753,8 +2753,8 @@ end subroutine overrides_create
     Model%fixed_sollat     = fixed_sollat
     Model%daily_mean       = daily_mean
     Model%do_diagnostic_radiation_with_scaled_co2 = do_diagnostic_radiation_with_scaled_co2
-    Model%diagnostic_radiation_call_co2_scale_factors = diagnostic_radiation_call_co2_scale_factors
-    Model%n_diagnostic_radiation_calls = count(Model%diagnostic_radiation_call_co2_scale_factors .ne. -999.0)
+    Model%diagnostic_radiation_co2_scale_factors = diagnostic_radiation_co2_scale_factors
+    Model%n_diagnostic_radiation_calls = count(Model%diagnostic_radiation_co2_scale_factors .ne. -999.0)
 
     !--- microphysical switch
     Model%ncld             = ncld
@@ -3455,7 +3455,7 @@ end subroutine overrides_create
       print *, ' fixed_sollat      : ', Model%fixed_sollat
       print *, ' daily_mean        : ', Model%daily_mean
       print *, ' do_diagnostic_radiation_with_scaled_co2 : ', Model%do_diagnostic_radiation_with_scaled_co2
-      print *, ' diagnostic_radiation_call_co2_scale_factors : ', Model%diagnostic_radiation_call_co2_scale_factors
+      print *, ' diagnostic_radiation_co2_scale_factors : ', Model%diagnostic_radiation_co2_scale_factors
       print *, ' n_diagnostic_radiation_calls : ', Model%n_diagnostic_radiation_calls
       print *, ' '
       print *, 'microphysical switch'

--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -347,14 +347,14 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: visbmui(:)     => null()   !< sfc uv+vis beam sw upward flux (w/m2)
     real (kind=kind_phys), pointer :: visdfui(:)     => null()   !< sfc uv+vis diff sw upward flux (w/m2)
 
-    real (kind=kind_phys), pointer :: nirbmdi_double_call(:)     => null()   !< sfc nir beam sw downward flux with scaled carbon dioxide (w/m2)
-    real (kind=kind_phys), pointer :: nirdfdi_double_call(:)     => null()   !< sfc nir diff sw downward flux with scaled carbon dioxide (w/m2)
-    real (kind=kind_phys), pointer :: visbmdi_double_call(:)     => null()   !< sfc uv+vis beam sw downward flux with scaled carbon dioxide (w/m2)
-    real (kind=kind_phys), pointer :: visdfdi_double_call(:)     => null()   !< sfc uv+vis diff sw downward flux with scaled carbon dioxide (w/m2)
-    real (kind=kind_phys), pointer :: nirbmui_double_call(:)     => null()   !< sfc nir beam sw upward flux with scaled carbon dioxide (w/m2)
-    real (kind=kind_phys), pointer :: nirdfui_double_call(:)     => null()   !< sfc nir diff sw upward flux with scaled carbon dioxide (w/m2)
-    real (kind=kind_phys), pointer :: visbmui_double_call(:)     => null()   !< sfc uv+vis beam sw upward flux with scaled carbon dioxide (w/m2)
-    real (kind=kind_phys), pointer :: visdfui_double_call(:)     => null()   !< sfc uv+vis diff sw upward flux with scaled carbon dioxide (w/m2)
+    real (kind=kind_phys), pointer :: nirbmdi_double_call(:,:)     => null()   !< sfc nir beam sw downward flux with scaled carbon dioxide (w/m2)
+    real (kind=kind_phys), pointer :: nirdfdi_double_call(:,:)     => null()   !< sfc nir diff sw downward flux with scaled carbon dioxide (w/m2)
+    real (kind=kind_phys), pointer :: visbmdi_double_call(:,:)     => null()   !< sfc uv+vis beam sw downward flux with scaled carbon dioxide (w/m2)
+    real (kind=kind_phys), pointer :: visdfdi_double_call(:,:)     => null()   !< sfc uv+vis diff sw downward flux with scaled carbon dioxide (w/m2)
+    real (kind=kind_phys), pointer :: nirbmui_double_call(:,:)     => null()   !< sfc nir beam sw upward flux with scaled carbon dioxide (w/m2)
+    real (kind=kind_phys), pointer :: nirdfui_double_call(:,:)     => null()   !< sfc nir diff sw upward flux with scaled carbon dioxide (w/m2)
+    real (kind=kind_phys), pointer :: visbmui_double_call(:,:)     => null()   !< sfc uv+vis beam sw upward flux with scaled carbon dioxide (w/m2)
+    real (kind=kind_phys), pointer :: visdfui_double_call(:,:)     => null()   !< sfc uv+vis diff sw upward flux with scaled carbon dioxide (w/m2)
 
     !--- In (physics only)
     real (kind=kind_phys), pointer :: sfcdsw(:)      => null()   !< total sky sfc downward sw flux ( w/m**2 )
@@ -364,11 +364,11 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: sfcdlw(:)      => null()   !< total sky sfc downward lw flux ( w/m**2 )
                                                                  !< GFS_radtend_type%sfclsw%dnfxc
 
-    real (kind=kind_phys), pointer :: sfcdsw_double_call(:)      => null()   !< total sky sfc downward sw flux with scaled carbon dioxide ( w/m**2 )
+    real (kind=kind_phys), pointer :: sfcdsw_double_call(:,:)      => null()   !< total sky sfc downward sw flux with scaled carbon dioxide ( w/m**2 )
                                                                  !< GFS_radtend_type%sfcfsw%dnfxc
-    real (kind=kind_phys), pointer :: sfcnsw_double_call(:)      => null()   !< total sky sfc netsw flx into ground with scaled carbon dioxide(w/m**2)
+    real (kind=kind_phys), pointer :: sfcnsw_double_call(:,:)      => null()   !< total sky sfc netsw flx into ground with scaled carbon dioxide(w/m**2)
                                                                  !< difference of dnfxc & upfxc from GFS_radtend_type%sfcfsw
-    real (kind=kind_phys), pointer :: sfcdlw_double_call(:)      => null()   !< total sky sfc downward lw flux with scaled carbon dioxide ( w/m**2 )
+    real (kind=kind_phys), pointer :: sfcdlw_double_call(:,:)      => null()   !< total sky sfc downward lw flux with scaled carbon dioxide ( w/m**2 )
                                                                  !< GFS_radtend_type%sfclsw%dnfxc
 
     !--- incoming quantities
@@ -571,7 +571,8 @@ module GFS_typedefs
     logical              :: fixed_sollat    !< flag to fix solar latitude
     logical              :: daily_mean      !< flag to replace cosz with daily mean value
     logical              :: do_radiation_double_call !< flag to call radiation a second time with scaled carbon dioxide
-    real(kind=kind_phys) :: radiation_double_call_co2_scale_factor  !< factor to scale carbon dioxide by in radiation double call
+    real(kind=kind_phys), dimension(8) :: radiation_double_call_co2_scale_factors !< factors to scale carbon dioxide by in radiation double calls
+    integer              :: n_radiation_double_calls  !< number of radiation double calls
 
     !--- microphysical switch
     integer              :: ncld            !< cnoice of cloud scheme
@@ -1052,28 +1053,28 @@ module GFS_typedefs
 !-----------------------------------------
 ! Optional arrays for outputs when calling the radiation code a second time with scaled carbon dioxide
 
-    type (sfcfsw_type),    pointer :: sfcfsw_double_call(:)   => null()   !< sw radiation fluxes at sfc with scaled carbon dioxide
-                                                                          !< [dim(im): created in grrad.f], components:
-                                                                          !!     (check module_radsw_parameters for definition)
-                                                                          !!\n   %upfxc - total sky upward sw flux at sfc (w/m**2)
-                                                                          !!\n   %upfx0 - clear sky upward sw flux at sfc (w/m**2)
-                                                                          !!\n   %dnfxc - total sky downward sw flux at sfc (w/m**2)
-                                                                          !!\n   %dnfx0 - clear sky downward sw flux at sfc (w/m**2)
+    type (sfcfsw_type),    pointer :: sfcfsw_double_call(:,:)   => null()   !< sw radiation fluxes at sfc with scaled carbon dioxide
+                                                                            !< [dim(im): created in grrad.f], components:
+                                                                            !!     (check module_radsw_parameters for definition)
+                                                                            !!\n   %upfxc - total sky upward sw flux at sfc (w/m**2)
+                                                                            !!\n   %upfx0 - clear sky upward sw flux at sfc (w/m**2)
+                                                                            !!\n   %dnfxc - total sky downward sw flux at sfc (w/m**2)
+                                                                            !!\n   %dnfx0 - clear sky downward sw flux at sfc (w/m**2)
 
-    type (sfcflw_type),    pointer :: sfcflw_double_call(:)    => null()  !< lw radiation fluxes at sfc with scaled carbon dioxide
-                                                                          !< [dim(im): created in grrad.f], components:
-                                                                          !!     (check module_radlw_paramters for definition)
-                                                                          !!\n   %upfxc - total sky upward lw flux at sfc (w/m**2)
-                                                                          !!\n   %upfx0 - clear sky upward lw flux at sfc (w/m**2)
-                                                                          !!\n   %dnfxc - total sky downward lw flux at sfc (w/m**2)
-                                                                          !!\n   %dnfx0 - clear sky downward lw flux at sfc (w/m**2)
+    type (sfcflw_type),    pointer :: sfcflw_double_call(:,:)    => null()  !< lw radiation fluxes at sfc with scaled carbon dioxide
+                                                                            !< [dim(im): created in grrad.f], components:
+                                                                            !!     (check module_radlw_paramters for definition)
+                                                                            !!\n   %upfxc - total sky upward lw flux at sfc (w/m**2)
+                                                                            !!\n   %upfx0 - clear sky upward lw flux at sfc (w/m**2)
+                                                                            !!\n   %dnfxc - total sky downward lw flux at sfc (w/m**2)
+                                                                            !!\n   %dnfx0 - clear sky downward lw flux at sfc (w/m**2)
 
-    real (kind=kind_phys), pointer :: htrsw_double_call (:,:)  => null()  !< swh  total sky sw heating rate in k/sec with scaled carbon dioxide
-    real (kind=kind_phys), pointer :: htrlw_double_call (:,:)  => null()  !< hlw  total sky lw heating rate in k/sec with scaled carbon dioxide
+    real (kind=kind_phys), pointer :: htrsw_double_call (:,:,:)  => null()  !< swh  total sky sw heating rate in k/sec with scaled carbon dioxide
+    real (kind=kind_phys), pointer :: htrlw_double_call (:,:,:)  => null()  !< hlw  total sky lw heating rate in k/sec with scaled carbon dioxide
 
-    real (kind=kind_phys), pointer :: swhc_double_call (:,:)   => null()  !< clear sky sw heating rates with scaled carbon dioxide ( k/s )
-    real (kind=kind_phys), pointer :: lwhc_double_call (:,:)   => null()  !< clear sky lw heating rates with scaled carbon dioxide ( k/s )
-    real (kind=kind_phys), pointer :: lwhd_double_call (:,:,:) => null()  !< idea sky lw heating rates with scaled carbon dioxide ( k/s )
+    real (kind=kind_phys), pointer :: swhc_double_call (:,:,:)   => null()  !< clear sky sw heating rates with scaled carbon dioxide ( k/s )
+    real (kind=kind_phys), pointer :: lwhc_double_call (:,:,:)   => null()  !< clear sky lw heating rates with scaled carbon dioxide ( k/s )
+    real (kind=kind_phys), pointer :: lwhd_double_call (:,:,:,:) => null()  !< idea sky lw heating rates with scaled carbon dioxide ( k/s )
 
     contains
       procedure :: create  => radtend_create   !<   allocate array data
@@ -1226,25 +1227,25 @@ module GFS_typedefs
     type (topflw_type),    pointer :: topflw(:)     => null()   !< lw radiation fluxes at top, component:
                                                !       %upfxc    - total sky upward lw flux at toa (w/m**2)
                                                !       %upfx0    - clear sky upward lw flux at toa (w/m**2)
-    type (topfsw_type),    pointer :: topfsw_double_call(:)     => null()   !< sw radiation fluxes at toa with scaled carbon dioxide, components:
-                                                           !       %upfxc    - total sky upward sw flux at toa (w/m**2)
-                                                           !       %dnfxc    - total sky downward sw flux at toa (w/m**2)
-                                                           !       %upfx0    - clear sky upward sw flux at toa (w/m**2)
-    type (topflw_type),    pointer :: topflw_double_call(:)     => null()   !< lw radiation fluxes at top with scaled carbon dioxide, component:
-                                                           !       %upfxc    - total sky upward lw flux at toa (w/m**2)
-                                                           !       %upfx0    - clear sky upward lw flux at toa (w/m**2)
-    real (kind=kind_phys), pointer :: dswrftoa_double_call(:) => null()  !< sw dn at toa with scaled carbon dioxide (w/m**2)
-    real (kind=kind_phys), pointer :: uswrftoa_double_call(:) => null()  !< sw up at toa with scaled carbon dioxide (w/m**2)
-    real (kind=kind_phys), pointer :: ulwrftoa_double_call(:) => null()  !< lw up at toa with scaled carbon dioxide (w/m**2)
+    type (topfsw_type),    pointer :: topfsw_double_call(:,:)     => null()   !< sw radiation fluxes at toa with scaled carbon dioxide, components:
+                                                             !       %upfxc    - total sky upward sw flux at toa (w/m**2)
+                                                             !       %dnfxc    - total sky downward sw flux at toa (w/m**2)
+                                                             !       %upfx0    - clear sky upward sw flux at toa (w/m**2)
+    type (topflw_type),    pointer :: topflw_double_call(:,:)     => null()   !< lw radiation fluxes at top with scaled carbon dioxide, component:
+                                                             !       %upfxc    - total sky upward lw flux at toa (w/m**2)
+                                                             !       %upfx0    - clear sky upward lw flux at toa (w/m**2)
+    real (kind=kind_phys), pointer :: dswrftoa_double_call(:,:) => null()  !< sw dn at toa with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: uswrftoa_double_call(:,:) => null()  !< sw up at toa with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: ulwrftoa_double_call(:,:) => null()  !< lw up at toa with scaled carbon dioxide (w/m**2)
 
-    real (kind=kind_phys), pointer :: dlwsfci_double_call(:) => null()   !< instantaneous lw dn at sfc with scaled carbon dioxide (w/m**2)
-    real (kind=kind_phys), pointer :: ulwsfci_double_call(:) => null()   !< instantaneous lw up at sfc with scaled carbon dioxide (w/m**2)
-    real (kind=kind_phys), pointer :: dswsfci_double_call(:) => null()   !< instantaneous sw dn at sfc with scaled carbon dioxide (w/m**2)
-    real (kind=kind_phys), pointer :: uswsfci_double_call(:) => null()   !< instantaneous sw up at sfc with scaled carbon dioxide (w/m**2)
-    real (kind=kind_phys), pointer :: dlwsfc_double_call(:) => null()    !< interval-average lw dn at sfc with scaled carbon dioxide (w/m**2)
-    real (kind=kind_phys), pointer :: ulwsfc_double_call(:) => null()    !< interval-average lw up at sfc with scaled carbon dioxide (w/m**2)
-    real (kind=kind_phys), pointer :: dswsfc_double_call(:) => null()    !< interval-average sw dn at sfc with scaled carbon dioxide (w/m**2)
-    real (kind=kind_phys), pointer :: uswsfc_double_call(:) => null()    !< interval-average sw up at sfc with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: dlwsfci_double_call(:,:) => null()   !< instantaneous lw dn at sfc with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: ulwsfci_double_call(:,:) => null()   !< instantaneous lw up at sfc with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: dswsfci_double_call(:,:) => null()   !< instantaneous sw dn at sfc with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: uswsfci_double_call(:,:) => null()   !< instantaneous sw up at sfc with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: dlwsfc_double_call(:,:) => null()    !< interval-average lw dn at sfc with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: ulwsfc_double_call(:,:) => null()    !< interval-average lw up at sfc with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: dswsfc_double_call(:,:) => null()    !< interval-average sw dn at sfc with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: uswsfc_double_call(:,:) => null()    !< interval-average sw up at sfc with scaled carbon dioxide (w/m**2)
 
 #if defined (USE_COSP) || defined (COSP_OFFLINE)
     type (cosp_type)               :: cosp                      !< cosp output
@@ -1389,7 +1390,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: co2(:,:) => null()  ! Vertically resolved CO2 concentration
     real (kind=kind_phys), pointer :: column_moles_co2_per_square_meter(:) => null()  ! Moles of CO2 in column per square meter
     real (kind=kind_phys), pointer :: column_moles_dry_air_per_square_meter(:) => null()  ! Moles of dry air in column per square meter
-    real (kind=kind_phys), pointer :: column_moles_co2_per_square_meter_radiation_double_call(:) => null()  ! Moles of CO2 in column per square meter in radiation double call
+    real (kind=kind_phys), pointer :: column_moles_co2_per_square_meter_radiation_double_call(:,:) => null()  ! Moles of CO2 in column per square meter in radiation double call
 
     !--- accumulated quantities for 3D diagnostics
     real (kind=kind_phys), pointer :: upd_mf (:,:)   => null()  !< instantaneous convective updraft mass flux
@@ -1925,14 +1926,14 @@ module GFS_typedefs
     Coupling%sfcdlw    = clear_val
 
     if (Model%do_radiation_double_call) then
-       allocate (Coupling%nirbmdi_double_call  (IM))
-       allocate (Coupling%nirdfdi_double_call  (IM))
-       allocate (Coupling%visbmdi_double_call  (IM))
-       allocate (Coupling%visdfdi_double_call  (IM))
-       allocate (Coupling%nirbmui_double_call  (IM))
-       allocate (Coupling%nirdfui_double_call  (IM))
-       allocate (Coupling%visbmui_double_call  (IM))
-       allocate (Coupling%visdfui_double_call  (IM))
+       allocate (Coupling%nirbmdi_double_call  (Model%n_radiation_double_calls,IM))
+       allocate (Coupling%nirdfdi_double_call  (Model%n_radiation_double_calls,IM))
+       allocate (Coupling%visbmdi_double_call  (Model%n_radiation_double_calls,IM))
+       allocate (Coupling%visdfdi_double_call  (Model%n_radiation_double_calls,IM))
+       allocate (Coupling%nirbmui_double_call  (Model%n_radiation_double_calls,IM))
+       allocate (Coupling%nirdfui_double_call  (Model%n_radiation_double_calls,IM))
+       allocate (Coupling%visbmui_double_call  (Model%n_radiation_double_calls,IM))
+       allocate (Coupling%visdfui_double_call  (Model%n_radiation_double_calls,IM))
 
        Coupling%nirbmdi_double_call = clear_val
        Coupling%nirdfdi_double_call = clear_val
@@ -1943,9 +1944,9 @@ module GFS_typedefs
        Coupling%visbmui_double_call = clear_val
        Coupling%visdfui_double_call = clear_val
 
-       allocate (Coupling%sfcdsw_double_call    (IM))
-       allocate (Coupling%sfcnsw_double_call    (IM))
-       allocate (Coupling%sfcdlw_double_call    (IM))
+       allocate (Coupling%sfcdsw_double_call    (Model%n_radiation_double_calls,IM))
+       allocate (Coupling%sfcnsw_double_call    (Model%n_radiation_double_calls,IM))
+       allocate (Coupling%sfcdlw_double_call    (Model%n_radiation_double_calls,IM))
 
        Coupling%sfcdsw_double_call    = clear_val
        Coupling%sfcnsw_double_call    = clear_val
@@ -2281,7 +2282,7 @@ end subroutine overrides_create
     logical              :: fixed_sollat   = .false.         !< flag to fix solar latitude
     logical              :: daily_mean     = .false.         !< flag to replace cosz with daily mean value
     logical              :: do_radiation_double_call = .false.  !< flag to call radiation a second time with scaled carbon dioxide
-    real(kind=kind_phys) :: radiation_double_call_co2_scale_factor = 1.0  !< factor to scale carbon dioxide by in radiation double call
+    real(kind=kind_phys), dimension(8) :: radiation_double_call_co2_scale_factors = -999.0  !< factors to scale carbon dioxide by in radiation double calls
 
     !--- GFDL microphysical parameters
     logical              :: do_sat_adj   = .false.           !< flag for fast saturation adjustment
@@ -2573,7 +2574,7 @@ end subroutine overrides_create
                                isubc_lw, crick_proof, ccnorm, lwhtr, swhtr, nkld,           &
                                fixed_date, fixed_solhr, fixed_sollat, daily_mean, sollat,   &
                                do_radiation_double_call,                                    &
-                               radiation_double_call_co2_scale_factor,                      &
+                               radiation_double_call_co2_scale_factors,                     &
                           !--- microphysical parameterizations
                                ncld, do_sat_adj, zhao_mic, psautco, prautco,                &
                                evpco, wminco, fprcp, mg_dcs, mg_qcvar,                      &
@@ -2752,7 +2753,8 @@ end subroutine overrides_create
     Model%fixed_sollat     = fixed_sollat
     Model%daily_mean       = daily_mean
     Model%do_radiation_double_call = do_radiation_double_call
-    Model%radiation_double_call_co2_scale_factor = radiation_double_call_co2_scale_factor
+    Model%radiation_double_call_co2_scale_factors = radiation_double_call_co2_scale_factors
+    Model%n_radiation_double_calls = count(Model%radiation_double_call_co2_scale_factors .ne. -999.0)
 
     !--- microphysical switch
     Model%ncld             = ncld
@@ -3453,7 +3455,8 @@ end subroutine overrides_create
       print *, ' fixed_sollat      : ', Model%fixed_sollat
       print *, ' daily_mean        : ', Model%daily_mean
       print *, ' do_radiation_double_call : ', Model%do_radiation_double_call
-      print *, ' radiation_double_call_co2_scale_factor : ', Model%radiation_double_call_co2_scale_factor
+      print *, ' radiation_double_call_co2_scale_factors : ', Model%radiation_double_call_co2_scale_factors
+      print *, ' n_radiation_double_calls : ', Model%n_radiation_double_calls
       print *, ' '
       print *, 'microphysical switch'
       print *, ' ncld              : ', Model%ncld
@@ -3894,8 +3897,8 @@ end subroutine overrides_create
     Radtend%swhc  = clear_val
 
     if (Model%do_radiation_double_call) then
-       allocate (Radtend%sfcfsw_double_call (IM))
-       allocate (Radtend%sfcflw_double_call (IM))
+       allocate (Radtend%sfcfsw_double_call (Model%n_radiation_double_calls,IM))
+       allocate (Radtend%sfcflw_double_call (Model%n_radiation_double_calls,IM))
 
        Radtend%sfcfsw_double_call%upfxc = clear_val
        Radtend%sfcfsw_double_call%upfx0 = clear_val
@@ -3906,15 +3909,15 @@ end subroutine overrides_create
        Radtend%sfcflw_double_call%dnfxc = clear_val
        Radtend%sfcflw_double_call%dnfx0 = clear_val
 
-       allocate(Radtend%htrsw_double_call(IM,Model%levs))
-       allocate(Radtend%htrlw_double_call(IM,Model%levs))
+       allocate(Radtend%htrsw_double_call(Model%n_radiation_double_calls,IM,Model%levs))
+       allocate(Radtend%htrlw_double_call(Model%n_radiation_double_calls,IM,Model%levs))
 
        Radtend%htrsw_double_call  = clear_val
        Radtend%htrlw_double_call  = clear_val
 
-       allocate (Radtend%swhc_double_call  (IM,Model%levs))
-       allocate (Radtend%lwhc_double_call  (IM,Model%levs))
-       allocate (Radtend%lwhd_double_call  (IM,Model%levs,6))
+       allocate (Radtend%swhc_double_call  (Model%n_radiation_double_calls,IM,Model%levs))
+       allocate (Radtend%lwhc_double_call  (Model%n_radiation_double_calls,IM,Model%levs))
+       allocate (Radtend%lwhd_double_call  (Model%n_radiation_double_calls,IM,Model%levs,6))
 
        Radtend%lwhd_double_call  = clear_val
        Radtend%lwhc_double_call  = clear_val
@@ -3940,19 +3943,19 @@ end subroutine overrides_create
     allocate (Diag%topfsw  (IM))
     allocate (Diag%topflw  (IM))
     if (Model%do_radiation_double_call) then
-       allocate (Diag%topfsw_double_call  (IM))
-       allocate (Diag%topflw_double_call  (IM))
-       allocate (Diag%dswrftoa_double_call (IM))
-       allocate (Diag%uswrftoa_double_call (IM))
-       allocate (Diag%ulwrftoa_double_call (IM))
-       allocate (Diag%dlwsfci_double_call (IM))
-       allocate (Diag%ulwsfci_double_call (IM))
-       allocate (Diag%dswsfci_double_call (IM))
-       allocate (Diag%uswsfci_double_call (IM))
-       allocate (Diag%dlwsfc_double_call (IM))
-       allocate (Diag%ulwsfc_double_call (IM))
-       allocate (Diag%dswsfc_double_call (IM))
-       allocate (Diag%uswsfc_double_call (IM))
+       allocate (Diag%topfsw_double_call  (Model%n_radiation_double_calls,IM))
+       allocate (Diag%topflw_double_call  (Model%n_radiation_double_calls,IM))
+       allocate (Diag%dswrftoa_double_call (Model%n_radiation_double_calls,IM))
+       allocate (Diag%uswrftoa_double_call (Model%n_radiation_double_calls,IM))
+       allocate (Diag%ulwrftoa_double_call (Model%n_radiation_double_calls,IM))
+       allocate (Diag%dlwsfci_double_call (Model%n_radiation_double_calls,IM))
+       allocate (Diag%ulwsfci_double_call (Model%n_radiation_double_calls,IM))
+       allocate (Diag%dswsfci_double_call (Model%n_radiation_double_calls,IM))
+       allocate (Diag%uswsfci_double_call (Model%n_radiation_double_calls,IM))
+       allocate (Diag%dlwsfc_double_call (Model%n_radiation_double_calls,IM))
+       allocate (Diag%ulwsfc_double_call (Model%n_radiation_double_calls,IM))
+       allocate (Diag%dswsfc_double_call (Model%n_radiation_double_calls,IM))
+       allocate (Diag%uswsfc_double_call (Model%n_radiation_double_calls,IM))
     endif
     !--- Physics
     !--- In/Out
@@ -4083,7 +4086,7 @@ end subroutine overrides_create
       allocate (Diag%column_moles_dry_air_per_square_meter(IM))
 
       if (Model%do_radiation_double_call) then
-         allocate (Diag%column_moles_co2_per_square_meter_radiation_double_call(IM))
+         allocate (Diag%column_moles_co2_per_square_meter_radiation_double_call(Model%n_radiation_double_calls,IM))
       endif
 
       !--- needed to allocate GoCart coupling fields

--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -347,12 +347,28 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: visbmui(:)     => null()   !< sfc uv+vis beam sw upward flux (w/m2)
     real (kind=kind_phys), pointer :: visdfui(:)     => null()   !< sfc uv+vis diff sw upward flux (w/m2)
 
+    real (kind=kind_phys), pointer :: nirbmdi_double_call(:)     => null()   !< sfc nir beam sw downward flux with scaled carbon dioxide (w/m2)
+    real (kind=kind_phys), pointer :: nirdfdi_double_call(:)     => null()   !< sfc nir diff sw downward flux with scaled carbon dioxide (w/m2)
+    real (kind=kind_phys), pointer :: visbmdi_double_call(:)     => null()   !< sfc uv+vis beam sw downward flux with scaled carbon dioxide (w/m2)
+    real (kind=kind_phys), pointer :: visdfdi_double_call(:)     => null()   !< sfc uv+vis diff sw downward flux with scaled carbon dioxide (w/m2)
+    real (kind=kind_phys), pointer :: nirbmui_double_call(:)     => null()   !< sfc nir beam sw upward flux with scaled carbon dioxide (w/m2)
+    real (kind=kind_phys), pointer :: nirdfui_double_call(:)     => null()   !< sfc nir diff sw upward flux with scaled carbon dioxide (w/m2)
+    real (kind=kind_phys), pointer :: visbmui_double_call(:)     => null()   !< sfc uv+vis beam sw upward flux with scaled carbon dioxide (w/m2)
+    real (kind=kind_phys), pointer :: visdfui_double_call(:)     => null()   !< sfc uv+vis diff sw upward flux with scaled carbon dioxide (w/m2)
+
     !--- In (physics only)
     real (kind=kind_phys), pointer :: sfcdsw(:)      => null()   !< total sky sfc downward sw flux ( w/m**2 )
                                                                  !< GFS_radtend_type%sfcfsw%dnfxc
     real (kind=kind_phys), pointer :: sfcnsw(:)      => null()   !< total sky sfc netsw flx into ground(w/m**2)
                                                                  !< difference of dnfxc & upfxc from GFS_radtend_type%sfcfsw
     real (kind=kind_phys), pointer :: sfcdlw(:)      => null()   !< total sky sfc downward lw flux ( w/m**2 )
+                                                                 !< GFS_radtend_type%sfclsw%dnfxc
+
+    real (kind=kind_phys), pointer :: sfcdsw_double_call(:)      => null()   !< total sky sfc downward sw flux with scaled carbon dioxide ( w/m**2 )
+                                                                 !< GFS_radtend_type%sfcfsw%dnfxc
+    real (kind=kind_phys), pointer :: sfcnsw_double_call(:)      => null()   !< total sky sfc netsw flx into ground with scaled carbon dioxide(w/m**2)
+                                                                 !< difference of dnfxc & upfxc from GFS_radtend_type%sfcfsw
+    real (kind=kind_phys), pointer :: sfcdlw_double_call(:)      => null()   !< total sky sfc downward lw flux with scaled carbon dioxide ( w/m**2 )
                                                                  !< GFS_radtend_type%sfclsw%dnfxc
 
     !--- incoming quantities
@@ -554,6 +570,8 @@ module GFS_typedefs
     logical              :: fixed_solhr     !< flag to fix solar angle to initial time
     logical              :: fixed_sollat    !< flag to fix solar latitude
     logical              :: daily_mean      !< flag to replace cosz with daily mean value
+    logical              :: do_radiation_double_call !< flag to call radiation a second time with scaled carbon dioxide
+    real(kind=kind_phys) :: radiation_double_call_co2_scale_factor  !< factor to scale carbon dioxide by in radiation double call
 
     !--- microphysical switch
     integer              :: ncld            !< cnoice of cloud scheme
@@ -1031,6 +1049,32 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: lwhc (:,:)   => null()  !< clear sky lw heating rates ( k/s )
     real (kind=kind_phys), pointer :: lwhd (:,:,:) => null()  !< idea sky lw heating rates ( k/s )
 
+!-----------------------------------------
+! Optional arrays for outputs when calling the radiation code a second time with scaled carbon dioxide
+
+    type (sfcfsw_type),    pointer :: sfcfsw_double_call(:)   => null()   !< sw radiation fluxes at sfc with scaled carbon dioxide
+                                                                          !< [dim(im): created in grrad.f], components:
+                                                                          !!     (check module_radsw_parameters for definition)
+                                                                          !!\n   %upfxc - total sky upward sw flux at sfc (w/m**2)
+                                                                          !!\n   %upfx0 - clear sky upward sw flux at sfc (w/m**2)
+                                                                          !!\n   %dnfxc - total sky downward sw flux at sfc (w/m**2)
+                                                                          !!\n   %dnfx0 - clear sky downward sw flux at sfc (w/m**2)
+
+    type (sfcflw_type),    pointer :: sfcflw_double_call(:)    => null()  !< lw radiation fluxes at sfc with scaled carbon dioxide
+                                                                          !< [dim(im): created in grrad.f], components:
+                                                                          !!     (check module_radlw_paramters for definition)
+                                                                          !!\n   %upfxc - total sky upward lw flux at sfc (w/m**2)
+                                                                          !!\n   %upfx0 - clear sky upward lw flux at sfc (w/m**2)
+                                                                          !!\n   %dnfxc - total sky downward lw flux at sfc (w/m**2)
+                                                                          !!\n   %dnfx0 - clear sky downward lw flux at sfc (w/m**2)
+
+    real (kind=kind_phys), pointer :: htrsw_double_call (:,:)  => null()  !< swh  total sky sw heating rate in k/sec with scaled carbon dioxide
+    real (kind=kind_phys), pointer :: htrlw_double_call (:,:)  => null()  !< hlw  total sky lw heating rate in k/sec with scaled carbon dioxide
+
+    real (kind=kind_phys), pointer :: swhc_double_call (:,:)   => null()  !< clear sky sw heating rates with scaled carbon dioxide ( k/s )
+    real (kind=kind_phys), pointer :: lwhc_double_call (:,:)   => null()  !< clear sky lw heating rates with scaled carbon dioxide ( k/s )
+    real (kind=kind_phys), pointer :: lwhd_double_call (:,:,:) => null()  !< idea sky lw heating rates with scaled carbon dioxide ( k/s )
+
     contains
       procedure :: create  => radtend_create   !<   allocate array data
   end type GFS_radtend_type
@@ -1182,6 +1226,26 @@ module GFS_typedefs
     type (topflw_type),    pointer :: topflw(:)     => null()   !< lw radiation fluxes at top, component:
                                                !       %upfxc    - total sky upward lw flux at toa (w/m**2)
                                                !       %upfx0    - clear sky upward lw flux at toa (w/m**2)
+    type (topfsw_type),    pointer :: topfsw_double_call(:)     => null()   !< sw radiation fluxes at toa with scaled carbon dioxide, components:
+                                                           !       %upfxc    - total sky upward sw flux at toa (w/m**2)
+                                                           !       %dnfxc    - total sky downward sw flux at toa (w/m**2)
+                                                           !       %upfx0    - clear sky upward sw flux at toa (w/m**2)
+    type (topflw_type),    pointer :: topflw_double_call(:)     => null()   !< lw radiation fluxes at top with scaled carbon dioxide, component:
+                                                           !       %upfxc    - total sky upward lw flux at toa (w/m**2)
+                                                           !       %upfx0    - clear sky upward lw flux at toa (w/m**2)
+    real (kind=kind_phys), pointer :: dswrftoa_double_call(:) => null()  !< sw dn at toa with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: uswrftoa_double_call(:) => null()  !< sw up at toa with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: ulwrftoa_double_call(:) => null()  !< lw up at toa with scaled carbon dioxide (w/m**2)
+
+    real (kind=kind_phys), pointer :: dlwsfci_double_call(:) => null()   !< instantaneous lw dn at sfc with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: ulwsfci_double_call(:) => null()   !< instantaneous lw up at sfc with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: dswsfci_double_call(:) => null()   !< instantaneous sw dn at sfc with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: uswsfci_double_call(:) => null()   !< instantaneous sw up at sfc with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: dlwsfc_double_call(:) => null()    !< interval-average lw dn at sfc with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: ulwsfc_double_call(:) => null()    !< interval-average lw up at sfc with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: dswsfc_double_call(:) => null()    !< interval-average sw dn at sfc with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: uswsfc_double_call(:) => null()    !< interval-average sw up at sfc with scaled carbon dioxide (w/m**2)
+
 #if defined (USE_COSP) || defined (COSP_OFFLINE)
     type (cosp_type)               :: cosp                      !< cosp output
 #endif
@@ -1325,6 +1389,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: co2(:,:) => null()  ! Vertically resolved CO2 concentration
     real (kind=kind_phys), pointer :: column_moles_co2_per_square_meter(:) => null()  ! Moles of CO2 in column per square meter
     real (kind=kind_phys), pointer :: column_moles_dry_air_per_square_meter(:) => null()  ! Moles of dry air in column per square meter
+    real (kind=kind_phys), pointer :: column_moles_co2_per_square_meter_radiation_double_call(:) => null()  ! Moles of CO2 in column per square meter in radiation double call
 
     !--- accumulated quantities for 3D diagnostics
     real (kind=kind_phys), pointer :: upd_mf (:,:)   => null()  !< instantaneous convective updraft mass flux
@@ -1859,6 +1924,34 @@ module GFS_typedefs
     Coupling%sfcnsw    = clear_val
     Coupling%sfcdlw    = clear_val
 
+    if (Model%do_radiation_double_call) then
+       allocate (Coupling%nirbmdi_double_call  (IM))
+       allocate (Coupling%nirdfdi_double_call  (IM))
+       allocate (Coupling%visbmdi_double_call  (IM))
+       allocate (Coupling%visdfdi_double_call  (IM))
+       allocate (Coupling%nirbmui_double_call  (IM))
+       allocate (Coupling%nirdfui_double_call  (IM))
+       allocate (Coupling%visbmui_double_call  (IM))
+       allocate (Coupling%visdfui_double_call  (IM))
+
+       Coupling%nirbmdi_double_call = clear_val
+       Coupling%nirdfdi_double_call = clear_val
+       Coupling%visbmdi_double_call = clear_val
+       Coupling%visdfdi_double_call = clear_val
+       Coupling%nirbmui_double_call = clear_val
+       Coupling%nirdfui_double_call = clear_val
+       Coupling%visbmui_double_call = clear_val
+       Coupling%visdfui_double_call = clear_val
+
+       allocate (Coupling%sfcdsw_double_call    (IM))
+       allocate (Coupling%sfcnsw_double_call    (IM))
+       allocate (Coupling%sfcdlw_double_call    (IM))
+
+       Coupling%sfcdsw_double_call    = clear_val
+       Coupling%sfcnsw_double_call    = clear_val
+       Coupling%sfcdlw_double_call    = clear_val
+    endif
+
     if (Model%cplflx .or. Model%do_sppt) then
       allocate (Coupling%rain_cpl     (IM))
       allocate (Coupling%snow_cpl     (IM))
@@ -2187,6 +2280,8 @@ end subroutine overrides_create
     logical              :: fixed_solhr    = .false.         !< flag to fix solar angle to initial time
     logical              :: fixed_sollat   = .false.         !< flag to fix solar latitude
     logical              :: daily_mean     = .false.         !< flag to replace cosz with daily mean value
+    logical              :: do_radiation_double_call = .false.  !< flag to call radiation a second time with scaled carbon dioxide
+    real(kind=kind_phys) :: radiation_double_call_co2_scale_factor = 1.0  !< factor to scale carbon dioxide by in radiation double call
 
     !--- GFDL microphysical parameters
     logical              :: do_sat_adj   = .false.           !< flag for fast saturation adjustment
@@ -2477,6 +2572,8 @@ end subroutine overrides_create
                                isot, iems,  iaer, iovr_sw, iovr_lw, ictm, isubc_sw,         &
                                isubc_lw, crick_proof, ccnorm, lwhtr, swhtr, nkld,           &
                                fixed_date, fixed_solhr, fixed_sollat, daily_mean, sollat,   &
+                               do_radiation_double_call,                                    &
+                               radiation_double_call_co2_scale_factor,                      &
                           !--- microphysical parameterizations
                                ncld, do_sat_adj, zhao_mic, psautco, prautco,                &
                                evpco, wminco, fprcp, mg_dcs, mg_qcvar,                      &
@@ -2654,6 +2751,8 @@ end subroutine overrides_create
     Model%fixed_solhr      = fixed_solhr
     Model%fixed_sollat     = fixed_sollat
     Model%daily_mean       = daily_mean
+    Model%do_radiation_double_call = do_radiation_double_call
+    Model%radiation_double_call_co2_scale_factor = radiation_double_call_co2_scale_factor
 
     !--- microphysical switch
     Model%ncld             = ncld
@@ -3353,6 +3452,8 @@ end subroutine overrides_create
       print *, ' fixed_solhr       : ', Model%fixed_solhr
       print *, ' fixed_sollat      : ', Model%fixed_sollat
       print *, ' daily_mean        : ', Model%daily_mean
+      print *, ' do_radiation_double_call : ', Model%do_radiation_double_call
+      print *, ' radiation_double_call_co2_scale_factor : ', Model%radiation_double_call_co2_scale_factor
       print *, ' '
       print *, 'microphysical switch'
       print *, ' ncld              : ', Model%ncld
@@ -3792,6 +3893,34 @@ end subroutine overrides_create
     Radtend%lwhc  = clear_val
     Radtend%swhc  = clear_val
 
+    if (Model%do_radiation_double_call) then
+       allocate (Radtend%sfcfsw_double_call (IM))
+       allocate (Radtend%sfcflw_double_call (IM))
+
+       Radtend%sfcfsw_double_call%upfxc = clear_val
+       Radtend%sfcfsw_double_call%upfx0 = clear_val
+       Radtend%sfcfsw_double_call%dnfxc = clear_val
+       Radtend%sfcfsw_double_call%dnfx0 = clear_val
+       Radtend%sfcflw_double_call%upfxc = clear_val
+       Radtend%sfcflw_double_call%upfx0 = clear_val
+       Radtend%sfcflw_double_call%dnfxc = clear_val
+       Radtend%sfcflw_double_call%dnfx0 = clear_val
+
+       allocate(Radtend%htrsw_double_call(IM,Model%levs))
+       allocate(Radtend%htrlw_double_call(IM,Model%levs))
+
+       Radtend%htrsw_double_call  = clear_val
+       Radtend%htrlw_double_call  = clear_val
+
+       allocate (Radtend%swhc_double_call  (IM,Model%levs))
+       allocate (Radtend%lwhc_double_call  (IM,Model%levs))
+       allocate (Radtend%lwhd_double_call  (IM,Model%levs,6))
+
+       Radtend%lwhd_double_call  = clear_val
+       Radtend%lwhc_double_call  = clear_val
+       Radtend%swhc_double_call  = clear_val
+    endif
+
   end subroutine radtend_create
 
 
@@ -3810,6 +3939,21 @@ end subroutine overrides_create
     allocate (Diag%ctau    (IM,Model%levs,2))
     allocate (Diag%topfsw  (IM))
     allocate (Diag%topflw  (IM))
+    if (Model%do_radiation_double_call) then
+       allocate (Diag%topfsw_double_call  (IM))
+       allocate (Diag%topflw_double_call  (IM))
+       allocate (Diag%dswrftoa_double_call (IM))
+       allocate (Diag%uswrftoa_double_call (IM))
+       allocate (Diag%ulwrftoa_double_call (IM))
+       allocate (Diag%dlwsfci_double_call (IM))
+       allocate (Diag%ulwsfci_double_call (IM))
+       allocate (Diag%dswsfci_double_call (IM))
+       allocate (Diag%uswsfci_double_call (IM))
+       allocate (Diag%dlwsfc_double_call (IM))
+       allocate (Diag%ulwsfc_double_call (IM))
+       allocate (Diag%dswsfc_double_call (IM))
+       allocate (Diag%uswsfc_double_call (IM))
+    endif
     !--- Physics
     !--- In/Out
     allocate (Diag%srunoff (IM))
@@ -3937,6 +4081,10 @@ end subroutine overrides_create
       allocate (Diag%co2(IM,Model%levs))
       allocate (Diag%column_moles_co2_per_square_meter(IM))
       allocate (Diag%column_moles_dry_air_per_square_meter(IM))
+
+      if (Model%do_radiation_double_call) then
+         allocate (Diag%column_moles_co2_per_square_meter_radiation_double_call(IM))
+      endif
 
       !--- needed to allocate GoCart coupling fields
       allocate (Diag%upd_mf (IM,Model%levs))
@@ -4091,6 +4239,24 @@ end subroutine overrides_create
       Diag%cldcov     = zero
     endif
 
+    if (Model%do_radiation_double_call) then
+       Diag%topfsw_double_call%upfxc = zero
+       Diag%topfsw_double_call%dnfxc = zero
+       Diag%topfsw_double_call%upfx0 = zero
+       Diag%topflw_double_call%upfxc = zero
+       Diag%topflw_double_call%upfx0 = zero
+       Diag%dswrftoa_double_call = zero
+       Diag%uswrftoa_double_call = zero
+       Diag%ulwrftoa_double_call = zero
+       Diag%dlwsfci_double_call = zero
+       Diag%ulwsfci_double_call = zero
+       Diag%dswsfci_double_call = zero
+       Diag%uswsfci_double_call = zero
+       Diag%dlwsfc_double_call = zero
+       Diag%ulwsfc_double_call = zero
+       Diag%dswsfc_double_call = zero
+       Diag%uswsfc_double_call = zero
+    endif
 
   end subroutine diag_rad_zero
 

--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -1051,7 +1051,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: lwhd (:,:,:) => null()  !< idea sky lw heating rates ( k/s )
 
 !-----------------------------------------
-! Optional arrays for outputs when calling the radiation code a second time with scaled carbon dioxide
+! Optional arrays for outputs when calling the radiation code a multiple times with scaled carbon dioxide for diagnostic purposes
 
     type (sfcfsw_type),    pointer :: sfcfsw_with_scaled_co2(:,:)   => null()   !< sw radiation fluxes at sfc with scaled carbon dioxide
                                                                             !< [dim(im): created in grrad.f], components:


### PR DESCRIPTION
**Description**

This PR adds the ability to output dual radiative flux diagnostics representing what the fluxes would be with up to eight different user-specified scalings of carbon dioxide.  These diagnostics are made optional, since for each provided scale factor an additional call to the radiative transfer code must be made.  The motivation for these diagnostics is to make it possible to quantify the impact of modifying the CO2 concentration for a given atmospheric state.  This flavor of diagnostic is often used to quantify the direct forcing of other constituents like aerosols.

#### Usage

Enabling these diagnostics requires modifying two namelist parameters:
- `gfs_physics_nml.do_diagnostic_radiation_with_scaled_co2` must be set to `.true.`.
- `gfs_physics_nml.diagnostic_radiation_co2_scale_factors` must be provided a sequence of float scale factors.  This sequence can be up to 8 values long, and controls the scale factors for CO2 in the additional diagnostic radiation calls.

For example something like the following would result in two additional radiation calls with 0x and 4x the prescribed CO2:
```
&gfs_physics_nml
    do_diagnostic_radiation_with_scaled_co2 = .true.
    diagnostic_radiation_co2_scale_factors = 0.0, 4.0
/
```

These namelist parameters expose new surface and top of atmosphere radiative flux diagnostics, which can be added in the diagnostics table.

##### With 0x CO2

- `DSWRFtoa_with_scaled_co2_1`
- `USWRFtoa_with_scaled_co2_1`
- `ULWRFtoa_with_scaled_co2_1`
- `DSWRF_with_scaled_co2_1`
- `USWRF_with_scaled_co2_1`
- `DLWRF_with_scaled_co2_1`
- `ULWRF_with_scaled_co2_1`
- `DSWRFI_with_scaled_co2_1`
- `USWRFI_with_scaled_co2_1`
- `DLWRFI_with_scaled_co2_1`
- `ULWRFI_with_scaled_co2_1`
- `global_mean_co2_1`

##### With 4xCO2

- `DSWRFtoa_with_scaled_co2_2`
- `USWRFtoa_with_scaled_co2_2`
- `ULWRFtoa_with_scaled_co2_2`
- `DSWRF_with_scaled_co2_2`
- `USWRF_with_scaled_co2_2`
- `DLWRF_with_scaled_co2_2`
- `ULWRF_with_scaled_co2_2`
- `DSWRFI_with_scaled_co2_2`
- `USWRFI_with_scaled_co2_2`
- `DLWRFI_with_scaled_co2_2`
- `ULWRFI_with_scaled_co2_2`
- `global_mean_co2_2`

Here the integer index trailing each internal name corresponds to the position in the sequence of provided scale factors.  The `long_name` of each diagnostic will include the actual CO2 scaling used in its generation.

cc: @lharris4

**How Has This Been Tested?**

This has been tested by ensuring that:
- Using a scale factor of 1.0 produces radiative flux diagnostics that bit-for-bit reproduce the main radiative flux diagnostics.
- Using other scale factors, e.g. 0.0 and 4.0, produces plausible results if we compare to results with a scale factor of 1.0.
- Running with these multiple diagnostic radiation calls does not change the evolution of the model.

[This notebook](https://gist.github.com/spencerkclark/d5d0344d17366a290684991f68edf57e) comprehensively illustrates the first two bullet points of these tests.

#### Difference between 4xCO2 and 1xCO2

![2024-06-24-radiation-multi-call-six-hour-interval-4xCO2-difference](https://github.com/NOAA-GFDL/SHiELD_physics/assets/6628425/5b07b620-62c2-4ef5-be44-a163827c113b)

#### Difference between 0xCO2 and 1xCO2

![2024-06-24-radiation-multi-call-six-hour-interval-0xCO2-difference](https://github.com/NOAA-GFDL/SHiELD_physics/assets/6628425/48efd8ca-ac70-4c0c-8289-16aeeab29bb2)

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
