### PR TITLE
Fixes and updates related to Noah-MP

### DIFF
--- a/FV3GFS/FV3GFS_io.F90
+++ b/FV3GFS/FV3GFS_io.F90
@@ -877,6 +877,7 @@ module FV3GFS_io_mod
     real(kind=kind_phys) :: masslai, masssai,snd
     real(kind=kind_phys) :: ddz,expon,aa,bb,smc,func,dfunc,dx
     real(kind=kind_phys) :: bexp, smcmax, smcwlt,dwsat,dksat,psisat
+    real(kind=kind_phys) :: emg, emv
 
     real(kind=kind_phys), dimension(-2:0) :: dzsno
     real(kind=kind_phys), dimension(-2:4) :: dzsnso
@@ -1351,7 +1352,6 @@ module FV3GFS_io_mod
                 Sfcprop(nb)%albdnir(ix)  = 0.2
                 Sfcprop(nb)%albivis(ix)  = 0.2
                 Sfcprop(nb)%albinir(ix)  = 0.2
-                Sfcprop(nb)%emiss(ix)    = 0.95
 
                 Sfcprop(nb)%waxy(ix)     = 4900.0
                 Sfcprop(nb)%wtxy(ix)     = Sfcprop(nb)%waxy(ix)
@@ -1393,6 +1393,10 @@ module FV3GFS_io_mod
                   Sfcprop(nb)%fastcpxy(ix) = 1000.0
 
                 endif  ! non urban ...
+
+                emv = 1. - exp(-(Sfcprop(nb)%xlaixy(ix)+Sfcprop(nb)%xsaixy(ix))/1.0) ! Ignore snow-buried sai and lai during the initialization
+                emg = 0.97*(1.-Sfcprop(nb)%sncovr(ix)) + 1.0*Sfcprop(nb)%sncovr(ix)
+                Sfcprop(nb)%emiss(ix) = Sfcprop(nb)%vfrac(ix) * ( emg*(1-emv) + emv + emv*(1-emv)*(1-emg) ) + (1-Sfcprop(nb)%vfrac(ix)) * emg
 
                 if ( vegtyp == isice_table )  then
                   do lsoil = 1,Model%lsoil

--- a/FV3GFS/FV3GFS_io.F90
+++ b/FV3GFS/FV3GFS_io.F90
@@ -1409,7 +1409,15 @@ module FV3GFS_io_mod
                 snd   = Sfcprop(nb)%snowd(ix)/1000.0  ! go to m from snwdph
 
                 if (Sfcprop(nb)%weasd(ix) /= 0.0 .and. snd == 0.0 ) then
-                  snd = Sfcprop(nb)%weasd(ix)/1000.0
+                  snd = Sfcprop(nb)%weasd(ix)*0.005
+                  Sfcprop(nb)%snowd(ix) = snd*1000.0
+                endif
+
+                ! cap SNOW at 2000, maintain density
+                if (Sfcprop(nb)%weasd(ix) > 2000.0 ) then
+                  snd = snd * 2000.0 / Sfcprop(nb)%weasd(ix)
+                  Sfcprop(nb)%weasd(ix) = 2000.0
+                  Sfcprop(nb)%snowd(ix) = snd*1000.0
                 endif
 
                 if (vegtyp == 15) then                      ! land ice in MODIS/IGBP

--- a/GFS_layer/GFS_physics_driver.F90
+++ b/GFS_layer/GFS_physics_driver.F90
@@ -1468,6 +1468,7 @@ module module_physics_driver
          if (dry(i)) then
           Sfcprop%t2m(i) = t2mmp(i)
           Sfcprop%q2m(i) = q2mp(i)
+          Sfcprop%emiss(i) = Radtend%semis(i)
          endif
         enddo
       endif 

--- a/GFS_layer/GFS_physics_driver.F90
+++ b/GFS_layer/GFS_physics_driver.F90
@@ -3676,7 +3676,7 @@ module module_physics_driver
           Sfcprop%drainncprv(:)  = tem * (frain * rain1(:))
           Sfcprop%dsnowprv(:)    = tem * Diag%snow(:)
           Sfcprop%dgraupelprv(:) = tem * Diag%graupel(:)
-          Sfcprop%diceprv(:)     = tem * Diag%ice(:)
+          Sfcprop%diceprv(:)     = 0.0
         else
           Sfcprop%draincprv(:)   = 0.0
           Sfcprop%drainncprv(:)  = 0.0

--- a/gsmphys/module_sf_noahmplsm.f90
+++ b/gsmphys/module_sf_noahmplsm.f90
@@ -784,7 +784,7 @@ contains
 
 !jref: seems like pair should be p1000mb??
        pair   = sfcprs                   ! atm bottom level pressure (pa)
-       thair  = sfctmp * (sfcprs/pair)**(rair/cpair) 
+       thair  = sfctmp * (100000./pair)**(rair/cpair) 
 
        qair   = q2                       ! in wrf, driver converts to specific humidity
 

--- a/gsmphys/sfc_noahmp_drv.f
+++ b/gsmphys/sfc_noahmp_drv.f
@@ -318,7 +318,8 @@
 
       do i = 1, im
         if (flag_iter(i) .and. flag(i)) then
-          q0(i)   = max(q1(i), 1.e-8)   !* q1=specific humidity at level 1 (kg/kg)
+          q0(i) = q1(i) / (1. - q1(i))  ! convert to mixing ratio (q0)
+          q0(i)   = max(q0(i), 1.e-8)  
           theta1(i) = t1(i) * prslki(i) !* adiabatic temp at level 1 (k)
 
           tv1(i) = t1(i) * (1.0 + con_fvirt*q0(i))

--- a/gsmphys/sfc_noahmp_drv.f
+++ b/gsmphys/sfc_noahmp_drv.f
@@ -12,7 +12,7 @@
      &       iopt_inf,iopt_rad, iopt_alb, iopt_snf,iopt_tbot,iopt_stc,  &
      &       iopt_gla,                                                  &
      &       xlatin,xcoszin, iyrlen, julian,imon,                       &
-     &       rainn_mp,rainc_mp,snow_mp,graupel_mp,ice_mp,               &
+     &       rainn_mp,rainc_mp,snow_mp,graupel_mp,hail_mp,               &
 
 !  ---  in/outs:
      &       weasd, snwdph, tskin, tprcp, srflag, smc, stc, slc,        &
@@ -92,7 +92,7 @@
      &       t1, q1, sigmaf, dlwflx, dswsfc, snet, tg3, cm,             &
      &       ch, prsl1, prslki, wind, shdmin, shdmax,                   &
      &       snoalb, zf,                                                &
-     &       rainn_mp,rainc_mp,snow_mp,graupel_mp,ice_mp
+     &       rainn_mp,rainc_mp,snow_mp,graupel_mp,hail_mp
 
       logical, dimension(im), intent(in) :: dry
 
@@ -556,7 +556,7 @@
           pshcv = 0.
           psnow = snow_mp(i)
           pgrpl = graupel_mp(i)
-          phail = ice_mp(i)
+          phail = hail_mp(i)
 !
 !-- old
 !

--- a/gsmphys/sfc_noahmp_drv.f
+++ b/gsmphys/sfc_noahmp_drv.f
@@ -447,7 +447,6 @@
           cmc = canopy(i)/1000.              ! convert from mm to m
           tsea = tsurf(i)                    ! clu_q2m_iter
 
-          snowh = snwdph(i) * 0.001         ! convert from mm to m
           sneqv = weasd(i)  * 0.001         ! convert from mm to m
 
 
@@ -563,10 +562,6 @@
           enddo
 
           snowh = snwdph(i) * 0.001         ! convert from mm to m
-
-          if (swe /= 0.0 .and. snowh == 0.0) then
-            snowh = 10.0 * swe /1000.0
-          endif
 
           chx    = chxy(i) ! maybe chxy  
           cmx    = cmxy(i)

--- a/gsmphys/sfc_noahmp_drv.f
+++ b/gsmphys/sfc_noahmp_drv.f
@@ -34,7 +34,6 @@
 !
 !
       use machine ,   only : kind_phys
-!     use date_def,   only : idate
       use funcphys,   only : fpvs
       use physcons,   only : con_g, con_hvap, con_cp, con_jcal,         &
      &                con_eps, con_epsm1, con_fvirt, con_rd,con_hfus
@@ -77,7 +76,6 @@
       real(kind=kind_phys), save  :: zsoil(4),sldpth(4)
       data zsoil / -0.1, -0.4, -1.0, -2.0 /
       data sldpth /0.1, 0.3, 0.6, 1.0 /
-!     data dzs /0.1, 0.3, 0.6, 1.0 /
 
 !
 !  ---  input:
@@ -174,7 +172,7 @@
      &       flx1, flx2, flx3, ffrozp, lwdn, pc, prcp, ptu, q2,         &
      &       q2sat, solnet, rc, rcs, rct, rcq, rcsoil, rsmin,           &
      &       runoff1, runoff2, runoff3, sfcspd, sfcprs, sfctmp,         &
-     &       sfcems, sheat, shdfac, shdmin1d, shdmax1d, smcwlt,         &
+     &       sheat, shdfac, shdmin1d, shdmax1d, smcwlt,                 &
      &       smcdry, smcref, smcmax, sneqv, snoalb1d, snowh,            &
      &       snomlt, sncovr, soilw, soilm, ssoil, tsea, th2,            &
      &       xlai, zlvl, swdn, tem, psfc,fdown,t2v,tbot, qmelt
@@ -388,7 +386,6 @@
           lwdn   = dlwflx(i)         !..downward lw flux at sfc in w/m2
           swdn   = dswsfc(i)         !..downward sw flux at sfc in w/m2
           solnet = snet(i)           !..net sw rad flx (dn-up) at sfc in w/m2
-          sfcems = sfcemis(i)
 
           sfctmp = t1(i)  
           sfcprs = prsl1(i) 
@@ -398,7 +395,6 @@
         if (prcp > 0.0) then
           if (ffrozp > 0.0) then                   ! rain/snow flag, one condition is enough?
             snowng = .true.
-            qsnowxy(i) = ffrozp * prcp/10.0                 !still use rho water?
           else
             if (sfctmp <= 275.15) frzgra = .true.  
           endif
@@ -652,7 +648,6 @@
         else
                  ice = 0 
 
-!        write(*,*)'tsnsox(1)=',tsnsox,'tgx=',tgx
        call noahmp_sflx (parameters                                    ,&
      &        i       , 1       , lat     , iyrlen  , julian  , cosz   ,& ! in : time/space-related
      &        delt    , dx      , dz8w    , nsoil   , zsoil   , nsnow  ,& ! in : model configuration 
@@ -764,9 +759,6 @@
           weasd(i)   = swe
           snwdph(i)  = snowh * 1000.0
 
-!         write(*,*) 'swe,snowh,can'
-!         write (*,*) swe,snowh*1000.0,canopy(i)
-!
           smcmax = smcmax_table(stype) 
           smcref = smcref_table(stype)
           smcwlt = smcwlt_table(stype)
@@ -793,12 +785,6 @@
           trans(i)   = fctr
           evap(i)    = eta
 
-!         write(*,*) 'vtype, stype are',vtype,stype
-!         write(*,*) 'fsh,gflx,eta',fsh,ssoil,eta
-!         write(*,*) 'esnow,runsrf,runsub',esnow,runsrf,runsub
-!         write(*,*) 'evbs,evcw,trans',fgev,fcev,fctr
-!         write(*,*) 'snowc',fsno
-
           tsurf(i)   = trad
           sfcemis(i) = emissi
           if(albedo .gt. 0.0) then
@@ -813,11 +799,10 @@
      &              1.0*smsoil(4))*1000.0  ! unit conversion from m to kg m-2
 !
           snohf (i) = qsnbot * con_hfus  ! only part of it but is diagnostic
-!         write(*,*) 'snohf',snohf(i)
+
 
           fdown     = fsa + lwdn
           t2v       = sfctmp * (1.0 + 0.61*q2)
-!         ssoil     = -1.0 *ssoil
 
        call penman (sfctmp,sfcprs,chx,t2v,th2,prcp,fdown,ssoil,         &
      &   q2,q2sat,etp,snowng,frzgra,ffrozp,dqsdt2,emissi,fsno)

--- a/gsmphys/sfc_noahmp_drv.f
+++ b/gsmphys/sfc_noahmp_drv.f
@@ -131,7 +131,6 @@
 
       integer, dimension(im)                   :: jsnowxy
       real (kind=kind_phys),dimension(im)      :: snodep
-      real (kind=kind_phys),dimension(im,-2:4) :: tsnsoxy
 
 !  ---  output:
 
@@ -489,11 +488,11 @@
           wtx      = waxy(i)     
 
           do k = -2,0
-           tsnsoxy(i,k) = tsnoxy(i,k)
+           tsnsox(k) = tsnoxy(i,k)
           enddo
 
           do k = 1,4
-           tsnsoxy(i,k) = stc(i,k)
+           tsnsox(k) = stc(i,k)
           enddo
 
          do k = -2,0
@@ -511,7 +510,6 @@
 
           do k = -2, km
             zsnsox(k)  = zsnsoxy(i,k)
-            tsnsox(k)  = tsnsoxy(i,k)
           enddo
 
           lfmassx  = lfmassxy(i)

--- a/gsmphys/sfc_noahmp_drv.f
+++ b/gsmphys/sfc_noahmp_drv.f
@@ -42,7 +42,7 @@
       use module_sf_noahmplsm
       use module_sf_noahmp_glacier
       use noahmp_tables, only : isice_table, co2_table, o2_table,       &
-     &                       isurban_table,smcref_table,smcdry_table,   &
+     &                       isurban_table,smcref_table,smcwlt_table,   &
      &                       smcmax_table,co2_table,o2_table,           &
      &                       saim_table,laim_table
 
@@ -769,7 +769,7 @@
 !
           smcmax = smcmax_table(stype) 
           smcref = smcref_table(stype)
-          smcwlt = smcdry_table(stype)
+          smcwlt = smcwlt_table(stype)
 !
 ! outs
 !

--- a/gsmphys/sfc_noahmp_drv.f
+++ b/gsmphys/sfc_noahmp_drv.f
@@ -540,8 +540,8 @@
           enddo
 
           smcwtdx        = smcwtdxy(i)
-          rechx          = rechxy(i)
-          deeprechx      = deeprechxy(i)
+          rechx          = 0.
+          deeprechx      = 0.
 !--
 !   the optional details for precip
 !--
@@ -633,10 +633,6 @@
          fastcpx = undefined
          xlaix   = undefined
          xsaix   = undefined
-
-         smcwtdx = 0.0
-         rechx   = 0.0
-         deeprechx       = 0.0
 
          do k = 1,4
          smoiseqx(k)   = smsoil(k)
@@ -750,8 +746,8 @@
 
              taussxy  (i)                = taussx
 
-             rechxy   (i)                = rechx
-             deeprechxy(i)               = deeprechx
+             rechxy   (i)                = rechxy(i) + rechx
+             deeprechxy(i)               = deeprechxy(i) + deeprechx
              smcwtdxy(i)                 = smcwtdx
              smoiseq(i,1:4)              = smoiseqx(1:4)
 


### PR DESCRIPTION
**Description**

A number of fixes, updates, and code clean-up related to Noah-MP:
1. fix issue with iems = 2, together with updated surface emissivity initialization. Originally, the surface emissivity was 0.95 everywhere anytime over land and sea-ice. The fix gives realistic spatial and temporal distribution of surface emissivity.
![image](https://github.com/NOAA-GFDL/SHiELD_physics/assets/74800123/521dd77e-1144-41cd-9c58-5fd7db9c631d)

2. fix wrong type of precipitation passed to Noah-MP. Specifically, this PR fixes that falling cloud ice was passed into Noah-MP as falling hail.

3. fix the representation of mixing ratio. Correct conversion from modified specific humidity (vapor_mass/[dry_mass + vapor_mass]; used in the GFS physics) to mixing ratio.
4. fix potential temperature calculation
5. fix water table recharge, based on [version 4.5 of the official Noah-MP repository](https://github.com/NCAR/noahmp/tree/noahmp_v4.5_develop)
6. update snow initialization, based on [version 4.5 of the official Noah-MP repository](https://github.com/NCAR/noahmp/tree/noahmp_v4.5_develop)
7. fix the output of wilting point 

cc: @spencerkclark and @lharris4 

**How Has This Been Tested?**

Tested on Gaea with a C96 case. Restart run and layout change do not change the answer.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
