### PR TITLE
CI: updating parallelworks scripts

### DIFF
--- a/.github/.parallelworks/checkout.sh
+++ b/.github/.parallelworks/checkout.sh
@@ -14,7 +14,7 @@ container_env_script=/contrib/containers/load_spack_noaa-intel.sh
 
 #Parse Arguments
 branch=main
-commit=""
+commit=none
 while [[ $# -gt 0 ]]; do
   case $1 in
     -b|--branch)
@@ -42,9 +42,6 @@ echo "commit is $commit"
 testDir=${dirRoot}/${intelVersion}/SHiELD_physics/${branch}/${commit}
 logDir=${testDir}/log
 export MODULESHOME=/usr/share/lmod/lmod
-#Define External Libs path
-export EXTERNAL_LIBS=${dirRoot}/${intelVersion}/SHiELD_physics/externallibs
-mkdir -p ${EXTERNAL_LIBS}
 ## create directories
 rm -rf ${testDir}
 mkdir -p ${logDir}
@@ -64,29 +61,4 @@ git clone --recursive https://github.com/NOAA-GFDL/SHiELD_build.git
 cd ${testDir}/SHiELD_build && ./CHECKOUT_code
 
 ## Check out the PR
-cd ${testDir}/SHiELD_SRC/SHiELD_physcis && git fetch origin ${branch}:toMerge && git merge toMerge
-
-##Check if we already have FMS compiled and recompile if version doesn't match what is in SHiELD_build checkout script
-grep -m 1 "fms_release" ${testDir}/SHiELD_build/CHECKOUT_code > ${logDir}/release.txt
-source ${logDir}/release.txt
-echo ${fms_release}
-echo `cat ${EXTERNAL_LIBS}/FMSversion`
-if [[ ${fms_release} != `cat ${EXTERNAL_LIBS}/FMSversion` ]]
-  then
-    #remove libFMS if it exists
-    if [ -d $EXTERNAL_LIBS/libFMS ]
-      then
-        rm -rf $EXTERNAL_LIBS/libFMS
-    fi
-    if [ -e $EXTERNAL_LIBS/FMSversion ]
-      then
-        rm $EXTERNAL_LIBS/FMSversion
-    fi
-    echo $fms_release > $EXTERNAL_LIBS/FMSversion
-    echo $container > $EXTERNAL_LIBS/FMScontainerversion
-    echo $container_env_script >> $EXTERNAL_LIBS/FMScontainerversion
-    # Build FMS
-    cd ${testDir}/SHiELD_build/Build
-    set -o pipefail
-    singularity exec -B /contrib ${container} ${container_env_script} "./BUILDlibfms intel"
- fi
+cd ${testDir}/SHiELD_SRC/SHiELD_physics && git fetch origin ${branch}:toMerge && git merge toMerge

--- a/.github/.parallelworks/compile.sh
+++ b/.github/.parallelworks/compile.sh
@@ -14,7 +14,7 @@ container_env_script=/contrib/containers/load_spack_noaa-intel.sh
 
 #Parse Arguments
 branch=main
-commit=""
+commit=none
 while [[ $# -gt 0 ]]; do
   case $1 in
     -b|--branch)
@@ -77,8 +77,8 @@ if [ $hydro = "sw" ] && [ $config = "shield" ]
     # Set up build
     cd ${testDir}/SHiELD_build/Build
     #Define External Libs path
-    export EXTERNAL_LIBS=${dirRoot}/${intelVersion}/SHiELD_physics/externallibs
+    export EXTERNAL_LIBS=${dirRoot}/externallibs
     # Build SHiELD
     set -o pipefail
-    singularity exec -B /contrib ${container} ${container_env_script} "./COMPILE ${config} ${hydro} ${bit} ${mode} intel clean"
+    singularity exec -B /contrib ${container} ${container_env_script} "./COMPILE ${config} ${hydro} ${bit} ${mode} intel clean" |& tee ${logDir}/compile_${config}_${hydro}_${bit}_${mode}_intel.out
 fi

--- a/.github/.parallelworks/run_test.sh
+++ b/.github/.parallelworks/run_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 ulimit -s unlimited
 ##############################################################################
-## User set up veriables
+## User set up variables
 ## Root directory for CI
 dirRoot=/contrib/fv3
 ## Intel version to be used
@@ -9,12 +9,12 @@ intelVersion=2023.2.0
 ##############################################################################
 ## HPC-ME container
 container=/contrib/containers/noaa-intel-prototype_2023.09.25.sif
-container_env_script=/contrib/containers/load_spack_noaa-intel.sh
+container_env_script=/contrib/containers/load_spack_noaa-intel-mlong.sh
 ##############################################################################
 
 #Parse Arguments
 branch=main
-commit=""
+commit=none
 while [[ $# -gt 0 ]]; do
   case $1 in
     -b|--branch)
@@ -66,7 +66,7 @@ runDir=${BUILDDIR}/CI/BATCH-CI
 cd ${testscriptDir}
 set -o pipefail
 # Execute the test piping output to log file
-./${testname} " --partition=p2 --mpi=pmi2 --job-name=${commit}_${testname} singularity exec -B /contrib ${container} ${container_env_script}" |& tee ${logDir}/run_${testname}.log
+./${testname} " --partition=compute --mpi=pmi2 --job-name=${commit}_${testname} singularity exec -B /contrib -B /apps ${container} ${container_env_script}" |& tee ${logDir}/run_${testname}.log
 
 ## Compare Restarts to Baseline
 #The following tests are not expectred to have run-to-run reproducibility:


### PR DESCRIPTION
**Description**

The scripts in .github/.parallelworks are stored on Parallelworks for use in the GitHub CI workflows.  They have been updated to better work on Parallelworks.

Fixes # (issue)

**How Has This Been Tested?**

This has been tested by this PRs CI working

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
