### PR TITLE
Expose 3D heating rates from radiation multi-calls as diagnostics

### DIFF
--- a/FV3GFS/FV3GFS_io.F90
+++ b/FV3GFS/FV3GFS_io.F90
@@ -3077,6 +3077,60 @@ module FV3GFS_io_mod
          Diag_diag_manager_controlled(index)%data(nb)%var3 => IntDiag(nb)%co2(:,:)
       enddo
 
+      if (Model%do_diagnostic_radiation_with_scaled_co2) then
+         do n = 1,Model%n_diagnostic_radiation_calls
+            write (radiation_call,'(I1)') n
+            write (scaling,'(F6.2)') Model%diagnostic_radiation_co2_scale_factors(n)
+
+            index = index + 1
+            Diag_diag_manager_controlled(index)%axes = 3
+            Diag_diag_manager_controlled(index)%name = 'tendency_of_air_temperature_due_to_longwave_heating_' // radiation_call
+            Diag_diag_manager_controlled(index)%desc = 'temperature tendency due to longwave radiation with ' // trim(adjustl(scaling)) // 'xCO2'
+            Diag_diag_manager_controlled(index)%unit = 'K/s'
+            Diag_diag_manager_controlled(index)%mod_name = 'gfs_phys'
+            Diag_diag_manager_controlled(index)%coarse_graining_method = MASS_WEIGHTED
+            allocate (Diag_diag_manager_controlled(index)%data(nblks))
+            do nb = 1,nblks
+               Diag_diag_manager_controlled(index)%data(nb)%var3 => IntDiag(nb)%htrlw_with_scaled_co2(n,:,:)
+            enddo
+
+            index = index + 1
+            Diag_diag_manager_controlled(index)%axes = 3
+            Diag_diag_manager_controlled(index)%name = 'tendency_of_air_temperature_due_to_shortwave_heating_' // radiation_call
+            Diag_diag_manager_controlled(index)%desc = 'temperature tendency due to shortwave radiation with ' // trim(adjustl(scaling)) // 'xCO2'
+            Diag_diag_manager_controlled(index)%unit = 'K/s'
+            Diag_diag_manager_controlled(index)%mod_name = 'gfs_phys'
+            Diag_diag_manager_controlled(index)%coarse_graining_method = MASS_WEIGHTED
+            allocate (Diag_diag_manager_controlled(index)%data(nblks))
+            do nb = 1,nblks
+               Diag_diag_manager_controlled(index)%data(nb)%var3 => IntDiag(nb)%htrsw_with_scaled_co2(n,:,:)
+            enddo
+
+            index = index + 1
+            Diag_diag_manager_controlled(index)%axes = 3
+            Diag_diag_manager_controlled(index)%name = 'tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky_' // radiation_call
+            Diag_diag_manager_controlled(index)%desc = 'temperature tendency due to longwave radiation assuming clear sky with ' // trim(adjustl(scaling)) // 'xCO2'
+            Diag_diag_manager_controlled(index)%unit = 'K/s'
+            Diag_diag_manager_controlled(index)%mod_name = 'gfs_phys'
+            Diag_diag_manager_controlled(index)%coarse_graining_method = MASS_WEIGHTED
+            allocate (Diag_diag_manager_controlled(index)%data(nblks))
+            do nb = 1,nblks
+               Diag_diag_manager_controlled(index)%data(nb)%var3 => IntDiag(nb)%lwhc_with_scaled_co2(n,:,:)
+            enddo
+
+            index = index + 1
+            Diag_diag_manager_controlled(index)%axes = 3
+            Diag_diag_manager_controlled(index)%name = 'tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_' // radiation_call
+            Diag_diag_manager_controlled(index)%desc = 'temperature tendency due to shortwave radiation assuming clear sky with ' // trim(adjustl(scaling)) // 'xCO2'
+            Diag_diag_manager_controlled(index)%unit = 'K/s'
+            Diag_diag_manager_controlled(index)%mod_name = 'gfs_phys'
+            Diag_diag_manager_controlled(index)%coarse_graining_method = MASS_WEIGHTED
+            allocate (Diag_diag_manager_controlled(index)%data(nblks))
+            do nb = 1,nblks
+               Diag_diag_manager_controlled(index)%data(nb)%var3 => IntDiag(nb)%swhc_with_scaled_co2(n,:,:)
+            enddo
+         enddo
+      endif
    endif
 
    index = index + 1

--- a/FV3GFS/FV3GFS_io.F90
+++ b/FV3GFS/FV3GFS_io.F90
@@ -3105,30 +3105,6 @@ module FV3GFS_io_mod
             do nb = 1,nblks
                Diag_diag_manager_controlled(index)%data(nb)%var3 => IntDiag(nb)%htrsw_with_scaled_co2(n,:,:)
             enddo
-
-            index = index + 1
-            Diag_diag_manager_controlled(index)%axes = 3
-            Diag_diag_manager_controlled(index)%name = 'tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky_with_scaled_co2_' // radiation_call
-            Diag_diag_manager_controlled(index)%desc = 'temperature tendency due to longwave radiation assuming clear sky with ' // trim(adjustl(scaling)) // 'xCO2'
-            Diag_diag_manager_controlled(index)%unit = 'K/s'
-            Diag_diag_manager_controlled(index)%mod_name = 'gfs_phys'
-            Diag_diag_manager_controlled(index)%coarse_graining_method = MASS_WEIGHTED
-            allocate (Diag_diag_manager_controlled(index)%data(nblks))
-            do nb = 1,nblks
-               Diag_diag_manager_controlled(index)%data(nb)%var3 => IntDiag(nb)%lwhc_with_scaled_co2(n,:,:)
-            enddo
-
-            index = index + 1
-            Diag_diag_manager_controlled(index)%axes = 3
-            Diag_diag_manager_controlled(index)%name = 'tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_with_scaled_co2_' // radiation_call
-            Diag_diag_manager_controlled(index)%desc = 'temperature tendency due to shortwave radiation assuming clear sky with ' // trim(adjustl(scaling)) // 'xCO2'
-            Diag_diag_manager_controlled(index)%unit = 'K/s'
-            Diag_diag_manager_controlled(index)%mod_name = 'gfs_phys'
-            Diag_diag_manager_controlled(index)%coarse_graining_method = MASS_WEIGHTED
-            allocate (Diag_diag_manager_controlled(index)%data(nblks))
-            do nb = 1,nblks
-               Diag_diag_manager_controlled(index)%data(nb)%var3 => IntDiag(nb)%swhc_with_scaled_co2(n,:,:)
-            enddo
          enddo
       endif
    endif

--- a/FV3GFS/FV3GFS_io.F90
+++ b/FV3GFS/FV3GFS_io.F90
@@ -3084,7 +3084,7 @@ module FV3GFS_io_mod
 
             index = index + 1
             Diag_diag_manager_controlled(index)%axes = 3
-            Diag_diag_manager_controlled(index)%name = 'tendency_of_air_temperature_due_to_longwave_heating_' // radiation_call
+            Diag_diag_manager_controlled(index)%name = 'tendency_of_air_temperature_due_to_longwave_heating_with_scaled_co2_' // radiation_call
             Diag_diag_manager_controlled(index)%desc = 'temperature tendency due to longwave radiation with ' // trim(adjustl(scaling)) // 'xCO2'
             Diag_diag_manager_controlled(index)%unit = 'K/s'
             Diag_diag_manager_controlled(index)%mod_name = 'gfs_phys'
@@ -3096,7 +3096,7 @@ module FV3GFS_io_mod
 
             index = index + 1
             Diag_diag_manager_controlled(index)%axes = 3
-            Diag_diag_manager_controlled(index)%name = 'tendency_of_air_temperature_due_to_shortwave_heating_' // radiation_call
+            Diag_diag_manager_controlled(index)%name = 'tendency_of_air_temperature_due_to_shortwave_heating_with_scaled_co2_' // radiation_call
             Diag_diag_manager_controlled(index)%desc = 'temperature tendency due to shortwave radiation with ' // trim(adjustl(scaling)) // 'xCO2'
             Diag_diag_manager_controlled(index)%unit = 'K/s'
             Diag_diag_manager_controlled(index)%mod_name = 'gfs_phys'
@@ -3108,7 +3108,7 @@ module FV3GFS_io_mod
 
             index = index + 1
             Diag_diag_manager_controlled(index)%axes = 3
-            Diag_diag_manager_controlled(index)%name = 'tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky_' // radiation_call
+            Diag_diag_manager_controlled(index)%name = 'tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky_with_scaled_co2_' // radiation_call
             Diag_diag_manager_controlled(index)%desc = 'temperature tendency due to longwave radiation assuming clear sky with ' // trim(adjustl(scaling)) // 'xCO2'
             Diag_diag_manager_controlled(index)%unit = 'K/s'
             Diag_diag_manager_controlled(index)%mod_name = 'gfs_phys'
@@ -3120,7 +3120,7 @@ module FV3GFS_io_mod
 
             index = index + 1
             Diag_diag_manager_controlled(index)%axes = 3
-            Diag_diag_manager_controlled(index)%name = 'tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_' // radiation_call
+            Diag_diag_manager_controlled(index)%name = 'tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_with_scaled_co2_' // radiation_call
             Diag_diag_manager_controlled(index)%desc = 'temperature tendency due to shortwave radiation assuming clear sky with ' // trim(adjustl(scaling)) // 'xCO2'
             Diag_diag_manager_controlled(index)%unit = 'K/s'
             Diag_diag_manager_controlled(index)%mod_name = 'gfs_phys'

--- a/GFS_layer/GFS_physics_driver.F90
+++ b/GFS_layer/GFS_physics_driver.F90
@@ -4400,8 +4400,6 @@ module module_physics_driver
            do k = 1, levs
              Diag%htrlw_with_scaled_co2(n,:,k) = Radtend%htrlw_with_scaled_co2(n,:,k)
              Diag%htrsw_with_scaled_co2(n,:,k) = Radtend%htrsw_with_scaled_co2(n,:,k) * xmu(:)
-             Diag%lwhc_with_scaled_co2(n,:,k) = Radtend%lwhc_with_scaled_co2(n,:,k)
-             Diag%swhc_with_scaled_co2(n,:,k) = Radtend%swhc_with_scaled_co2(n,:,k) * xmu(:)
            enddo
         endif
      enddo
@@ -4423,8 +4421,6 @@ module module_physics_driver
      do n = 1, Model%n_diagnostic_radiation_calls
         Diag%htrlw_with_scaled_co2(n,:,:) = con_cp * Diag%htrlw_with_scaled_co2(n,:,:) / specific_heat(:,:)
         Diag%htrsw_with_scaled_co2(n,:,:) = con_cp * Diag%htrsw_with_scaled_co2(n,:,:) / specific_heat(:,:)
-        Diag%lwhc_with_scaled_co2(n,:,:) = con_cp * Diag%lwhc_with_scaled_co2(n,:,:) / specific_heat(:,:)
-        Diag%swhc_with_scaled_co2(n,:,:) = con_cp * Diag%swhc_with_scaled_co2(n,:,:) / specific_heat(:,:)
      enddo
   end subroutine update_multi_call_temperature_tendency_diagnostics
 

--- a/GFS_layer/GFS_physics_driver.F90
+++ b/GFS_layer/GFS_physics_driver.F90
@@ -4393,10 +4393,10 @@ module module_physics_driver
         Diag%dswsfc_with_scaled_co2(n,:) = Diag%dswsfc_with_scaled_co2(n,:) + adjsfcdsw * Model%dtf
 
         if (Model%ldiag3d) then
-           ! Save the 3d all-sky and clear-sky longwave and shortwave heating rates to
-           ! later expose them as diagnostics. Note we must be sure to adjust these at the 
-           ! end of the physics driver such that they are consistent with how they will be
-           ! felt when applied in the dynamical core.
+           ! Save the 3d all-sky longwave and shortwave heating rates to later expose them
+           ! as diagnostics. Note we must be sure to adjust these at the end of the physics
+           ! driver such that they are consistent with how they will be felt when applied
+           ! in the dynamical core.
            do k = 1, levs
              Diag%htrlw_with_scaled_co2(n,:,k) = Radtend%htrlw_with_scaled_co2(n,:,k)
              Diag%htrsw_with_scaled_co2(n,:,k) = Radtend%htrsw_with_scaled_co2(n,:,k) * xmu(:)

--- a/GFS_layer/GFS_physics_driver.F90
+++ b/GFS_layer/GFS_physics_driver.F90
@@ -4067,6 +4067,10 @@ module module_physics_driver
         call update_water_vapor_tendency_diagnostics(Diag%q_dt, Diag%q_dt_int, &
             dq3dt_initial, Diag%dq3dt, Statein%qgrs(:,:,1:nwat), Stateout%gq0(:,:,1:nwat), &
             final_dynamics_delp, im, levs, nwat, dtp)
+
+        if (Model%do_diagnostic_radiation_with_scaled_co2) then
+           call update_multi_call_temperature_tendency_diagnostics(Diag, Model, specific_heat, im, levs)
+        endif
       endif
 
       return
@@ -4347,7 +4351,7 @@ module module_physics_driver
      integer,                        intent(in)    :: ix, im, levs
      type(GFS_diag_type),            intent(inout) :: Diag
 
-     integer :: n
+     integer :: k, n
 
      ! Local variables that will get reused throughout the multi-call loop
      real(kind=kind_phys), dimension(im,levs) :: dtdt, dtdtc
@@ -4387,9 +4391,43 @@ module module_physics_driver
 
         Diag%uswsfc_with_scaled_co2(n,:) = Diag%uswsfc_with_scaled_co2(n,:) + (adjsfcdsw - adjsfcnsw) * Model%dtf
         Diag%dswsfc_with_scaled_co2(n,:) = Diag%dswsfc_with_scaled_co2(n,:) + adjsfcdsw * Model%dtf
-      enddo
+
+        if (Model%ldiag3d) then
+           ! Save the 3d all-sky and clear-sky longwave and shortwave heating rates to
+           ! later expose them as diagnostics. Note we must be sure to adjust these at the 
+           ! end of the physics driver such that they are consistent with how they will be
+           ! felt when applied in the dynamical core.
+           do k = 1, levs
+             Diag%htrlw_with_scaled_co2(n,:,k) = Radtend%htrlw_with_scaled_co2(n,:,k)
+             Diag%htrsw_with_scaled_co2(n,:,k) = Radtend%htrsw_with_scaled_co2(n,:,k) * xmu(:)
+             Diag%lwhc_with_scaled_co2(n,:,k) = Radtend%lwhc_with_scaled_co2(n,:,k)
+             Diag%swhc_with_scaled_co2(n,:,k) = Radtend%swhc_with_scaled_co2(n,:,k) * xmu(:)
+           enddo
+        endif
+     enddo
 
   end subroutine compute_diagnostics_with_scaled_co2
+
+  ! Scale the 3d temperature tendency for each radiation component with 
+  ! scaled co2 by cp / cvm if the dynamical core is non-hydrostatic or 
+  ! cp / cpm if the dynamical core is hydrostatic to account for how
+  ! the temperature tendency is adjusted within the dynamical core.
+  subroutine update_multi_call_temperature_tendency_diagnostics(Diag, Model, specific_heat, im, levs)
+     type(GFS_diag_type),            intent(inout) :: Diag
+     type(GFS_control_type),         intent(in)    :: Model
+     integer,                        intent(in)    :: im, levs
+     real(kind=kind_phys),           intent(in)    :: specific_heat(1:im,1:levs)
+
+     integer :: n
+
+     do n = 1, Model%n_diagnostic_radiation_calls
+        Diag%htrlw_with_scaled_co2(n,:,:) = con_cp * Diag%htrlw_with_scaled_co2(n,:,:) / specific_heat(:,:)
+        Diag%htrsw_with_scaled_co2(n,:,:) = con_cp * Diag%htrsw_with_scaled_co2(n,:,:) / specific_heat(:,:)
+        Diag%lwhc_with_scaled_co2(n,:,:) = con_cp * Diag%lwhc_with_scaled_co2(n,:,:) / specific_heat(:,:)
+        Diag%swhc_with_scaled_co2(n,:,:) = con_cp * Diag%swhc_with_scaled_co2(n,:,:) / specific_heat(:,:)
+     enddo
+  end subroutine update_multi_call_temperature_tendency_diagnostics
+
 !> @}
 
 end module module_physics_driver

--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -1271,6 +1271,11 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: dswsfc_with_scaled_co2(:,:) => null()    !< interval-average sw dn at sfc with scaled carbon dioxide (w/m**2)
     real (kind=kind_phys), pointer :: uswsfc_with_scaled_co2(:,:) => null()    !< interval-average sw up at sfc with scaled carbon dioxide (w/m**2)
 
+    real (kind=kind_phys), pointer :: htrlw_with_scaled_co2(:,:,:) => null()    !< instantaneous 3d all-sky longwave radiative heating rate with scaled co2
+    real (kind=kind_phys), pointer :: htrsw_with_scaled_co2(:,:,:) => null()    !< instantaneous 3d all-sky shortwave radiative heating rate with scaled co2
+    real (kind=kind_phys), pointer :: lwhc_with_scaled_co2(:,:,:) => null()     !< instantaneous 3d clear-sky longwave radiative heating rate with scaled co2
+    real (kind=kind_phys), pointer :: swhc_with_scaled_co2(:,:,:) => null()     !< instantaneous 3d clear-sky shortwave radiative heating rate with scaled co2
+
 #if defined (USE_COSP) || defined (COSP_OFFLINE)
     type (cosp_type)               :: cosp                      !< cosp output
 #endif
@@ -4054,6 +4059,12 @@ end subroutine overrides_create
        allocate (Diag%ulwsfc_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM))
        allocate (Diag%dswsfc_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM))
        allocate (Diag%uswsfc_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM))
+       if (Model%ldiag3d) then
+          allocate (Diag%htrlw_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM,Model%levs))
+          allocate (Diag%htrsw_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM,Model%levs))
+          allocate (Diag%lwhc_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM,Model%levs))
+          allocate (Diag%swhc_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM,Model%levs))
+       endif
     endif
     !--- Physics
     !--- In/Out
@@ -4361,6 +4372,9 @@ end subroutine overrides_create
        Diag%ulwsfc_with_scaled_co2 = zero
        Diag%dswsfc_with_scaled_co2 = zero
        Diag%uswsfc_with_scaled_co2 = zero
+       ! Note the 3d radiation multi-call diagnostics are handled as
+       ! diagnostics manager controlled fields, so they do not need
+       ! to be manually zeroed, so we do not touch them here.
     endif
 
   end subroutine diag_rad_zero

--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -1273,8 +1273,6 @@ module GFS_typedefs
 
     real (kind=kind_phys), pointer :: htrlw_with_scaled_co2(:,:,:) => null()    !< instantaneous 3d all-sky longwave radiative heating rate with scaled co2
     real (kind=kind_phys), pointer :: htrsw_with_scaled_co2(:,:,:) => null()    !< instantaneous 3d all-sky shortwave radiative heating rate with scaled co2
-    real (kind=kind_phys), pointer :: lwhc_with_scaled_co2(:,:,:) => null()     !< instantaneous 3d clear-sky longwave radiative heating rate with scaled co2
-    real (kind=kind_phys), pointer :: swhc_with_scaled_co2(:,:,:) => null()     !< instantaneous 3d clear-sky shortwave radiative heating rate with scaled co2
 
 #if defined (USE_COSP) || defined (COSP_OFFLINE)
     type (cosp_type)               :: cosp                      !< cosp output
@@ -4062,8 +4060,6 @@ end subroutine overrides_create
        if (Model%ldiag3d) then
           allocate (Diag%htrlw_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM,Model%levs))
           allocate (Diag%htrsw_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM,Model%levs))
-          allocate (Diag%lwhc_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM,Model%levs))
-          allocate (Diag%swhc_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM,Model%levs))
        endif
     endif
     !--- Physics


### PR DESCRIPTION
**Description**

#51 introduced the machinery to compute and output radiation diagnostics from SHiELD with scaled CO2 concentration.  However, it only provided diagnostics for the surface and top of atmosphere fluxes.  Having vertically resolved heating rate information can also be valuable.  This PR makes the mostly boilerplate / plumbing updates needed to expose the 3D heating rates computed by the radiation multi-calls as diagnostics in a similar way.

The usage is the same as that described in #51, though one must also specify `gfs_physics_nml.ldiag3d = .true.`.  The multi-call diagnostics exposed have names of the form:

- `gfs_phys/tendency_of_air_temperature_due_to_longwave_heating_with_scaled_co2_1`
- `gfs_phys/tendency_of_air_temperature_due_to_shortwave_heating_with_scaled_co2_1`
- `gfs_phys/tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky_with_scaled_co2_1`
- `gfs_phys/tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_with_scaled_co2_1`

As we do with the existing versions of these diagnostics—i.e. those with the model-active CO2 concentration—we scale their values by the appropriate ratio of $c_p$ to the moist specific heat relevant to the configuration of the dynamical core to ensure that what is output is consistent with how the tendencies would be felt by the rest of the model.

Note these are diagnostics-manager-controlled fields, meaning that time aggregation (e.g. snapshot versus interval-averaged) can be configured through the diagnostics table.

**How Has This Been Tested?**

As in #51 this has been tested to ensure that:

- Using a scale factor of 1.0 produces radiative flux diagnostics that bitwise-reproduce the main radiative flux diagnostics.
- Using other scale factors, e.g. 0.0 and 4.0, produces plausible results if we compare to results with a scale factor of 1.0.
- Running with these multiple diagnostic radiation calls does not change the evolution of the model.

[This notebook](https://gist.github.com/spencerkclark/198c0baa8ccfb858a60a491089ff0d2b) illustrates the first two bullet points of these tests.

#### Difference between 4xCO2 and 1xCO2

![2025-01-08-vertical-profile-of-heating-rate-perturbations](https://github.com/user-attachments/assets/80aa6021-10c0-440e-93cc-0d32c40c6d26)

#### Difference between 0xCO2 and 1xCO2

![2025-01-08-vertical-profile-of-heating-rate-perturbations-0xCO2](https://github.com/user-attachments/assets/d7f4212c-4fec-4124-9876-06d39d67733a)

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
