### PR TITLE
Updates for handling inconsistent SHiELD and MOM6 land-sea masks

### DIFF
--- a/GFS_layer/GFS_physics_driver.F90
+++ b/GFS_layer/GFS_physics_driver.F90
@@ -1190,21 +1190,17 @@ module module_physics_driver
          !else
 !!$         endif
 
-            ! kgao - need a logic to ensure sfc_coupled is true when coupled with MOM6
             if (Model%sfc_coupled) then
-! a version of sfc_diff from coupling with MOM6 by kgao  
-! Sfcprop%uustar,Sfcprop%zorl,Sfcprop%ztrl are not updated over ocean points
-            call sfc_diff_coupled(im,Statein%pgr, Statein%ugrs, Statein%vgrs,&
+! a version of sfc_diff for coupling with MOM6 by kgao 
+! shflx is used as a flag to indicate if a grid point is a valid dynamical ocean point
+            call sfc_diff_coupled(im, Statein%pgr, Statein%ugrs, Statein%vgrs,&
                  Statein%tgrs, Statein%qgrs, Diag%zlvl, Sfcprop%snowd, &
                  Sfcprop%tsfc, Sfcprop%zorl, Sfcprop%ztrl, cd,      &
                  cdq, rb, Statein%prsl(1,1), work3, islmsk, stress, &
                  Sfcprop%ffmm,  Sfcprop%ffhh, Sfcprop%uustar,       &
                  wind,  Tbd%phy_f2d(1,Model%num_p2d), fm10, fh2,    &
                  sigmaf, vegtype, Sfcprop%shdmax, Model%ivegsrc,    &
-                 tsurf, flag_iter) !, Model%redrag, Model%z0s_max,     &
-                 !Model%do_z0_moon, Model%do_z0_hwrf15,              &
-                 !Model%do_z0_hwrf17, Model%do_z0_hwrf17_hwonly,     &
-                 !Model%wind_th_hwrf)
+                 tsurf, flag_iter, Sfcprop%shflx)
 
             else if (Model%sfc_gfdl) then
 ! a new and more flexible version of sfc_diff by kgao
@@ -1316,6 +1312,7 @@ module module_physics_driver
            (im, Statein%pgr, Statein%ugrs, Statein%vgrs, Statein%tgrs,  &
             Statein%qgrs, Sfcprop%tsfc, cd, cdq, Statein%prsl(1,1),     &
             work3, islmsk, Tbd%phy_f2d(1,Model%num_p2d), flag_iter,     &
+            maxevap,                                                    &
             ! kgao: shflx and lhflx from coupler 
             Sfcprop%shflx, Sfcprop%lhflx,                               &
 !  ---  outputs:

--- a/GFS_layer/GFS_physics_driver.F90
+++ b/GFS_layer/GFS_physics_driver.F90
@@ -1200,7 +1200,7 @@ module module_physics_driver
                  Sfcprop%ffmm,  Sfcprop%ffhh, Sfcprop%uustar,       &
                  wind,  Tbd%phy_f2d(1,Model%num_p2d), fm10, fh2,    &
                  sigmaf, vegtype, Sfcprop%shdmax, Model%ivegsrc,    &
-                 tsurf, flag_iter, Sfcprop%shflx)
+                 tsurf, flag_iter, Sfcprop%lhflx)
 
             else if (Model%sfc_gfdl) then
 ! a new and more flexible version of sfc_diff by kgao

--- a/GFS_layer/GFS_physics_driver.F90
+++ b/GFS_layer/GFS_physics_driver.F90
@@ -1192,7 +1192,7 @@ module module_physics_driver
 
             if (Model%sfc_coupled) then
 ! a version of sfc_diff for coupling with MOM6 by kgao 
-! shflx is used as a flag to indicate if a grid point is a valid dynamical ocean point
+! lhflx is used as a flag to indicate if a grid point is a valid dynamical ocean point
             call sfc_diff_coupled(im, Statein%pgr, Statein%ugrs, Statein%vgrs,&
                  Statein%tgrs, Statein%qgrs, Diag%zlvl, Sfcprop%snowd, &
                  Sfcprop%tsfc, Sfcprop%zorl, Sfcprop%ztrl, cd,      &

--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -661,7 +661,8 @@ module GFS_typedefs
     logical              :: shcnvcw         !< flag for shallow convective cloud
     logical              :: redrag          !< flag for reduced drag coeff. over sea
     logical              :: sfc_gfdl        !< flag for using updated sfc layer scheme
-    logical              :: sfc_coupled     !< flag for using sfc layer scheme designed for coupling
+    logical              :: sfc_coupled     !< flag for using sfc layer scheme designed for coupled SHiELD 
+                                            !< will set to true by atmos_driver; this is not a namelist parameter
     real(kind=kind_phys) :: z0s_max         !< a limiting value for z0 under high winds
     logical              :: do_z0_moon      !< flag for using z0 scheme in Moon et al. 2007 (kgao)
     logical              :: do_z0_hwrf15    !< flag for using z0 scheme in 2015 HWRF (kgao)
@@ -1726,8 +1727,8 @@ module GFS_typedefs
     Sfcprop%uustar  = clear_val
     Sfcprop%oro     = clear_val
     Sfcprop%oro_uf  = clear_val
-    Sfcprop%shflx   = clear_val
-    Sfcprop%lhflx   = clear_val
+    Sfcprop%shflx   = -999 !clear_val
+    Sfcprop%lhflx   = -999 !clear_val
 
     if (Model%myj_pbl) then
        allocate (Sfcprop%QZ0  (IM))
@@ -2393,7 +2394,7 @@ end subroutine overrides_create
     logical              :: shcnvcw        = .false.                  !< flag for shallow convective cloud
     logical              :: redrag         = .false.                  !< flag for reduced drag coeff. over sea
     logical              :: sfc_gfdl       = .false.                  !< flag for using new sfc layer scheme by kgao at GFDL
-    logical              :: sfc_coupled    = .false.                !< flag for using sfc layer scheme designed for coupling 
+    logical              :: sfc_coupled    = .false.                  !< flag for using sfc layer scheme designed for coupled SHiELD 
     real(kind=kind_phys) :: z0s_max        = .317e-2                  !< a limiting value for z0 under high winds
     logical              :: do_z0_moon     = .false.                  !< flag for using z0 scheme in Moon et al. 2007
     logical              :: do_z0_hwrf15   = .false.                  !< flag for using z0 scheme in 2015 HWRF
@@ -2647,7 +2648,7 @@ end subroutine overrides_create
                                ras, trans_trac, old_monin, cnvgwd, mstrat, moist_adj,       &
                                cscnv, cal_pre, do_aw, do_shoc, shocaftcnv, shoc_cld,        &
                                h2o_phys, pdfcld, shcnvcw, redrag, sfc_gfdl, z0s_max,        &
-                               sfc_coupled, do_z0_moon, do_z0_hwrf15, do_z0_hwrf17,         &
+                               do_z0_moon, do_z0_hwrf15, do_z0_hwrf17,                      &
                                do_z0_hwrf17_hwonly, wind_th_hwrf,                           &
                                hybedmf, dspheat, lheatstrg, hour_canopy, afac_canopy,       &
                                cnvcld, no_pbl, xkzm_lim, xkzm_fac, xkgdx,                   &
@@ -2888,7 +2889,6 @@ end subroutine overrides_create
     Model%shcnvcw          = shcnvcw
     Model%redrag           = redrag
     Model%sfc_gfdl         = sfc_gfdl
-    Model%sfc_coupled      = sfc_coupled
     Model%z0s_max          = z0s_max
     Model%do_z0_moon       = do_z0_moon
     Model%do_z0_hwrf15     = do_z0_hwrf15
@@ -3620,7 +3620,6 @@ end subroutine overrides_create
       print *, ' shcnvcw           : ', Model%shcnvcw
       print *, ' redrag            : ', Model%redrag
       print *, ' sfc_gfdl          : ', Model%sfc_gfdl
-      print *, ' sfc_coupled       : ', Model%sfc_coupled
       print *, ' z0s_max           : ', Model%z0s_max
       print *, ' do_z0_moon        : ', Model%do_z0_moon
       print *, ' do_z0_hwrf15      : ', Model%do_z0_hwrf15

--- a/gsmphys/sfc_diff_coupled.f
+++ b/gsmphys/sfc_diff_coupled.f
@@ -144,7 +144,7 @@
      &        rb(i), fm(i), fh(i), fm10(i), fh2(i),
      &        cm(i), ch(i), stress(i), ustar(i))
 
-          elseif (islimsk(i) == 0 .and. ocean_flag(i) .gt. 0 ) then
+          elseif (islimsk(i) == 0 .and. ocean_flag(i) .ne. -999 ) then
 
 !================================================ 
 ! this is a valid dynamical ocean point
@@ -170,7 +170,7 @@
             ! kgao: use ustar from coupler to get stress
             stress(i) =  ustar(i) * ustar(i)
 
-          elseif (islimsk(i) == 0 .and. ocean_flag (i) .le. 0) then
+          elseif (islimsk(i) == 0 .and. ocean_flag (i) .eq. -999) then
 
 !================================================ 
 ! this is a water point in SHiELD but not a 

--- a/gsmphys/sfc_diff_coupled.f
+++ b/gsmphys/sfc_diff_coupled.f
@@ -4,10 +4,7 @@
      &                    stress,fm,fh,
      &                    ustar,wind,ddvel,fm10,fh2,
      &                    sigmaf,vegtype,shdmax,ivegsrc,
-     &                    tsurf,flag_iter) !,redrag,
-!     &                    z0s_max)
-!     &                    do_z0_moon, do_z0_hwrf15, do_z0_hwrf17,
-!     &                    do_z0_hwrf17_hwonly, wind_th_hwrf)
+     &                    tsurf,flag_iter,ocean_flag)
 
       use machine , only : kind_phys
       use funcphys, only : fpvs    
@@ -26,7 +23,7 @@
      &,                                    prsl1, prslki, stress
      &,                                    fm, fh, ustar, wind, ddvel
      &,                                    fm10, fh2, sigmaf, shdmax
-     &,                                    tsurf, snwdph
+     &,                                    tsurf, snwdph, ocean_flag
       integer, dimension(im)             ::vegtype, islimsk
 
       logical   flag_iter(im)
@@ -147,14 +144,15 @@
      &        rb(i), fm(i), fh(i), fm10(i), fh2(i),
      &        cm(i), ch(i), stress(i), ustar(i))
 
-          elseif (islimsk(i) == 0) then
+          elseif (islimsk(i) == 0 .and. ocean_flag(i) .gt. 0 ) then
 
 !================================================ 
-! if over water 
-! - redesigned by Kun Gao for coupling with MOM6
-! - not updating z0, zt and ustar over ocean 
+! this is a valid dynamical ocean point
+! - designed by Kun Gao for coupling with MOM6
+! - use z0, zt and ustar directly from the coupler
+! - diagnose 2m and 10m var using SHiELD M-O 
 !================================================
-
+          
             ! --- z0/zt from coupler
             z0      = 0.01 * z0rl(i)
             zt      = 0.01 * ztrl(i)
@@ -171,6 +169,57 @@
 
             ! kgao: use ustar from coupler to get stress
             stress(i) =  ustar(i) * ustar(i)
+
+          elseif (islimsk(i) == 0 .and. ocean_flag (i) .le. 0) then
+
+!================================================ 
+! this is a water point in SHiELD but not a 
+! valid dynamical ocean point; use similar 
+! procedure as in uncoupled SHiELD (sfc_diff_gfdl.f) 
+!
+!    iteration 1 
+!         step 1 get z0/zt from previous step
+!         step 2 call similarity
+!    iteration 2 
+!         step 1 update z0/zt 
+!         step 2 call similarity 
+!================================================
+
+! === iteration 1
+
+            ! --- get z0/zt
+            z0      = 0.01 * z0rl(i)
+            zt      = 0.01 * ztrl(i)
+
+            z0max   = max(1.0e-6, min(z0,z1(i)))
+            ztmax   = max(zt,1.0e-6)
+
+            ! --- call similarity
+            call monin_obukhov_similarity
+     &       (z1(i), snwdph(i), thv1, wind(i), z0max, ztmax, tvs,
+     &        rb(i), fm(i), fh(i), fm10(i), fh2(i),
+     &        cm(i), ch(i), stress(i), ustar(i))
+
+! === iteration 2
+
+            u10m = u1(i) * fm10(i) / fm(i)
+            v10m = v1(i) * fm10(i) / fm(i)
+            ws10m = sqrt(u10m*u10m + v10m*v10m)
+
+            call cal_z0_hwrf17(ws10m, z0)
+            call cal_zt_hwrf17(ws10m, zt)
+
+            z0max = max(z0,1.0e-6)
+            ztmax  = max(zt,1.0e-6)
+
+            ! --- call similarity
+            call monin_obukhov_similarity
+     &       (z1(i), snwdph(i), thv1, wind(i), z0max, ztmax, tvs,
+     &        rb(i), fm(i), fh(i), fm10(i), fh2(i),
+     &        cm(i), ch(i), stress(i), ustar(i))
+
+            z0rl(i) = 100.0 * z0max
+            ztrl(i) = 100.0 * ztmax
 
           endif       ! end of if(islimsk) loop
         endif         ! end of if(flagiter) loop

--- a/gsmphys/sfc_ocean_coupled.f
+++ b/gsmphys/sfc_ocean_coupled.f
@@ -138,8 +138,9 @@
           tem      = 1.0 / rho
           qsurf(i) = qss
 
-          if ( shflx(i) == -999 ) then
-            !if not over a dynamical ocean point
+          if ( shflx(i) .eq. -999 ) then
+            !if not over a dynamical ocean point,
+            !use similar procedure as in uncoupled SHiELD (sfc_ocean.f)
             hflx(i)  = rch * (tskin(i) - t1(i) * prslki(i))
             evap(i)  = elocp*rch * (qss - q0)
             hflx(i)  = hflx(i) * tem * cpinv

--- a/gsmphys/sfc_ocean_coupled.f
+++ b/gsmphys/sfc_ocean_coupled.f
@@ -138,8 +138,8 @@
           tem      = 1.0 / rho
           qsurf(i) = qss
 
-          if ( shflx(i) .eq. -999 ) then
-            !if not over a dynamical ocean point,
+          if ( lhflx(i) .eq. -999 ) then
+            !if not over a valid dynamical ocean point,
             !use similar procedure as in uncoupled SHiELD (sfc_ocean.f)
             hflx(i)  = rch * (tskin(i) - t1(i) * prslki(i))
             evap(i)  = elocp*rch * (qss - q0)


### PR DESCRIPTION
Updates to SHiELD Surface physics subroutines to address inconsistent Land-Sea Masks between SHiELD and MOM6 in real-world applications

The logic behind the updates is as follows:

- For SHiELD "land" points: Always use the SHiELD land model (Noah or Noah MP).
- For SHiELD "sea" points:
  - If the corresponding points are also "sea" points in MOM6: Use surface data produced by the Coupler.
  - If the corresponding points are not "sea" points in MOM6: Use the surface physics built into SHiELD.

The inconsistent "sea" points in SHiELD and MOM6 can be categorized as follows:
- Lakes: SHiELD masks them as "sea" points, but MOM6 treats them as "land" points.
- Ocean Basins Not of Interest: Regional MOM6 may mask them out.
- Coastal Regions: SHiELD and MOM6 may have slightly inconsistent coastlines due to the use of different datasets/algorithms.

Additionally, the parameter `sfc_coupled` has been removed from the namelist in this update; its correct value will now be set by the atmos_driver for the coupled SHiELD.