### PR TITLE
Add zenith-angle-adjusted TOA shortwave flux diagnostics

### DIFF
--- a/FV3GFS/FV3GFS_io.F90
+++ b/FV3GFS/FV3GFS_io.F90
@@ -3564,6 +3564,60 @@ module FV3GFS_io_mod
 
     idx = idx + 1
     Diag(idx)%axes = 2
+    Diag(idx)%name = 'DSWRFtoa_adjusted'
+    Diag(idx)%desc = 'Interval-averaged zenith-angle-adjusted top of atmosphere downward shortwave flux'
+    Diag(idx)%unit = 'W/m**2'
+    Diag(idx)%mod_name = 'gfs_phys'
+    Diag(idx)%cnvfac = cn_one
+    Diag(idx)%time_avg = .TRUE.
+    Diag(idx)%intpl_method = 'bilinear'
+    allocate (Diag(idx)%data(nblks))
+    do nb = 1,nblks
+      Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswtoa(:)
+    enddo
+
+    idx = idx + 1
+    Diag(idx)%axes = 2
+    Diag(idx)%name = 'USWRFtoa_adjusted'
+    Diag(idx)%desc = 'Interval-averaged zenith-angle-adjusted top of atmosphere upward shortwave flux'
+    Diag(idx)%unit = 'W/m**2'
+    Diag(idx)%mod_name = 'gfs_phys'
+    Diag(idx)%cnvfac = cn_one
+    Diag(idx)%time_avg = .TRUE.
+    Diag(idx)%intpl_method = 'bilinear'
+    allocate (Diag(idx)%data(nblks))
+    do nb = 1,nblks
+      Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswtoa(:)
+    enddo
+
+    idx = idx + 1
+    Diag(idx)%axes = 2
+    Diag(idx)%name = 'DSWRFItoa_adjusted'
+    Diag(idx)%desc = 'Instantaneous zenith-angle-adjusted top of atmosphere downward shortwave flux'
+    Diag(idx)%unit = 'W/m**2'
+    Diag(idx)%mod_name = 'gfs_phys'
+    Diag(idx)%cnvfac = cn_one
+    Diag(idx)%intpl_method = 'bilinear'
+    allocate (Diag(idx)%data(nblks))
+    do nb = 1,nblks
+      Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswtoai(:)
+    enddo
+
+    idx = idx + 1
+    Diag(idx)%axes = 2
+    Diag(idx)%name = 'USWRFItoa_adjusted'
+    Diag(idx)%desc = 'Instantaneous zenith-angle-adjusted top of atmosphere upward shortwave flux'
+    Diag(idx)%unit = 'W/m**2'
+    Diag(idx)%mod_name = 'gfs_phys'
+    Diag(idx)%cnvfac = cn_one
+    Diag(idx)%intpl_method = 'bilinear'
+    allocate (Diag(idx)%data(nblks))
+    do nb = 1,nblks
+      Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswtoai(:)
+    enddo
+
+    idx = idx + 1
+    Diag(idx)%axes = 2
     Diag(idx)%name = 'ULWRFtoa'
     Diag(idx)%desc = 'top of atmos upward longwave flux [W/m**2]'
     Diag(idx)%unit = 'W/m**2'
@@ -3625,6 +3679,60 @@ module FV3GFS_io_mod
          allocate (Diag(idx)%data(nblks))
          do nb = 1,nblks
            Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%ulwrftoa_with_scaled_co2(n,:)
+         enddo
+
+         idx = idx + 1
+         Diag(idx)%axes = 2
+         Diag(idx)%name = 'DSWRFtoa_adjusted_with_scaled_co2_' // trim(xtra)
+         Diag(idx)%desc = 'Interval-averaged zenith-angle-adjusted top of atmosphere downward shortwave flux with ' // trim(adjustl(scaling)) // 'xCO2'
+         Diag(idx)%unit = 'W/m**2'
+         Diag(idx)%mod_name = 'gfs_phys'
+         Diag(idx)%cnvfac = cn_one
+         Diag(idx)%time_avg = .TRUE.
+         Diag(idx)%intpl_method = 'bilinear'
+         allocate (Diag(idx)%data(nblks))
+         do nb = 1,nblks
+           Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswtoa_with_scaled_co2(n,:)
+         enddo
+
+         idx = idx + 1
+         Diag(idx)%axes = 2
+         Diag(idx)%name = 'USWRFtoa_adjusted_with_scaled_co2_' // trim(xtra)
+         Diag(idx)%desc = 'Interval-averaged zenith-angle-adjusted top of atmosphere upward shortwave flux with ' // trim(adjustl(scaling)) // 'xCO2'
+         Diag(idx)%unit = 'W/m**2'
+         Diag(idx)%mod_name = 'gfs_phys'
+         Diag(idx)%cnvfac = cn_one
+         Diag(idx)%time_avg = .TRUE.
+         Diag(idx)%intpl_method = 'bilinear'
+         allocate (Diag(idx)%data(nblks))
+         do nb = 1,nblks
+           Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswtoa_with_scaled_co2(n,:)
+         enddo
+
+         idx = idx + 1
+         Diag(idx)%axes = 2
+         Diag(idx)%name = 'DSWRFItoa_adjusted_with_scaled_co2_' // trim(xtra)
+         Diag(idx)%desc = 'Instantaneous zenith-angle-adjusted top of atmosphere downward shortwave flux with ' // trim(adjustl(scaling)) // 'xCO2'
+         Diag(idx)%unit = 'W/m**2'
+         Diag(idx)%mod_name = 'gfs_phys'
+         Diag(idx)%cnvfac = cn_one
+         Diag(idx)%intpl_method = 'bilinear'
+         allocate (Diag(idx)%data(nblks))
+         do nb = 1,nblks
+           Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%dswtoai_with_scaled_co2(n,:)
+         enddo
+
+         idx = idx + 1
+         Diag(idx)%axes = 2
+         Diag(idx)%name = 'USWRFItoa_adjusted_with_scaled_co2_' // trim(xtra)
+         Diag(idx)%desc = 'Instantaneous zenith-angle-adjusted top of atmosphere upward shortwave flux with ' // trim(adjustl(scaling)) // 'xCO2'
+         Diag(idx)%unit = 'W/m**2'
+         Diag(idx)%mod_name = 'gfs_phys'
+         Diag(idx)%cnvfac = cn_one
+         Diag(idx)%intpl_method = 'bilinear'
+         allocate (Diag(idx)%data(nblks))
+         do nb = 1,nblks
+           Diag(idx)%data(nb)%var2 => Gfs_diag(nb)%uswtoai_with_scaled_co2(n,:)
          enddo
        enddo
     endif

--- a/GFS_layer/GFS_physics_driver.F90
+++ b/GFS_layer/GFS_physics_driver.F90
@@ -462,7 +462,7 @@ module module_physics_driver
            stress, t850, ep1d, gamt, gamq, sigmaf, oc, theta, gamma,    &
            sigma, elvmax, wind, work1, work2, runof, xmu, fm10, fh2,    &
            tsurf,  tx1, tx2, ctei_r, evbs, evcw, trans, sbsno, snowc,   &
-           frland, adjsfculw, maxevap,                                  &
+           frland, adjsfculw, maxevap, adjtoadsw, adjtoausw,            &
            adjnirbmu, adjnirdfu, adjvisbmu, adjvisdfu, adjnirbmd,       &
            adjnirdfd, adjvisbmd, adjvisdfd, gabsbdlw, xcosz, tseal,     &
            snohf, dlqfac, work3, ctei_rml, cldf, domr, domzr, domip,    &
@@ -876,17 +876,18 @@ module module_physics_driver
              Grid%coslat, Grid%xlon, Radtend%coszen, Sfcprop%tsfc,          &
              Statein%tgrs(1,1), Radtend%tsflw, Radtend%semis,               &
              Coupling%sfcdsw, Coupling%sfcnsw, Coupling%sfcdlw,             &
-             Radtend%htrsw, Radtend%swhc, Radtend%htrlw, Radtend%lwhc,      &
-             Coupling%nirbmui, Coupling%nirdfui, Coupling%visbmui,          &
-             Coupling%visdfui, Coupling%nirbmdi, Coupling%nirdfdi,          &
-             Coupling%visbmdi, Coupling%visdfdi, ix, im, levs,              &
-             Model%daily_mean,                                              &
+             Diag%topfsw, Radtend%htrsw, Radtend%swhc, Radtend%htrlw,       &
+             Radtend%lwhc, Coupling%nirbmui, Coupling%nirdfui,              &
+             Coupling%visbmui, Coupling%visdfui, Coupling%nirbmdi,          &
+             Coupling%nirdfdi, Coupling%visbmdi, Coupling%visdfdi, ix, im,  &
+             levs, Model%daily_mean,                                        &
 !  ---  input/output:
              dtdt, dtdtc,                                                   &
 !  ---  outputs:
              adjsfcdsw, adjsfcnsw, adjsfcdlw, adjsfculw, xmu, xcosz,        &
              adjnirbmu, adjnirdfu, adjvisbmu, adjvisdfu,                    &
-             adjnirbmd, adjnirdfd, adjvisbmd, adjvisdfd                     &
+             adjnirbmd, adjnirdfd, adjvisbmd, adjvisdfd,                    &
+             adjtoadsw, adjtoausw                                           &
            )
 
         if (Model%do_diagnostic_radiation_with_scaled_co2) then
@@ -959,6 +960,11 @@ module module_physics_driver
           Diag%uswsfc_override(:) = Diag%uswsfc_override(:) + (adjsfcdsw_for_coupling(:) - adjsfcnsw_for_coupling(:))*dtf
           Diag%dlwsfc_override(:) = Diag%dlwsfc_override(:) + adjsfcdlw_for_coupling(:)*dtf
         endif
+
+        Diag%dswtoa(:) = Diag%dswtoa(:) + adjtoadsw(:)*dtf
+        Diag%uswtoa(:) = Diag%uswtoa(:) + adjtoausw(:)*dtf
+        Diag%dswtoai(:) = adjtoadsw(:)
+        Diag%uswtoai(:) = adjtoausw(:)
 
         if (Model%ldiag3d) then
           if (Model%lsidea) then
@@ -4354,7 +4360,7 @@ module module_physics_driver
      real(kind=kind_phys), dimension(im,levs) :: dtdt, dtdtc
      real(kind=kind_phys), dimension(im) :: adjsfcdsw, adjsfcnsw, adjsfcdlw, &
         adjsfculw, adjnirbmu, adjnirdfu, adjvisbmu, adjvisdfu, adjnirbmd,    &
-        adjnirdfd, adjvisbmd, adjvisdfd, xmu, xcosz
+        adjnirdfd, adjvisbmd, adjvisdfd, adjtoadsw, adjtoausw, xmu, xcosz
 
      do n = 1, Model%n_diagnostic_radiation_calls
         call dcyc2t3                                                                        &
@@ -4363,23 +4369,29 @@ module module_physics_driver
              Grid%coslat, Grid%xlon, Radtend%coszen, Sfcprop%tsfc,                          &
              Statein%tgrs(1,1), Radtend%tsflw, Radtend%semis,                               &
              Coupling%sfcdsw_with_scaled_co2(n,:), Coupling%sfcnsw_with_scaled_co2(n,:),    &
-             Coupling%sfcdlw_with_scaled_co2(n,:), Radtend%htrsw_with_scaled_co2(n,:,:),    &
-             Radtend%swhc_with_scaled_co2(n,:,:), Radtend%htrlw_with_scaled_co2(n,:,:),     &
-             Radtend%lwhc_with_scaled_co2(n,:,:), Coupling%nirbmui_with_scaled_co2(n,:),    &
-             Coupling%nirdfui_with_scaled_co2(n,:), Coupling%visbmui_with_scaled_co2(n,:),  &
-             Coupling%visdfui_with_scaled_co2(n,:), Coupling%nirbmdi_with_scaled_co2(n,:),  &
-             Coupling%nirdfdi_with_scaled_co2(n,:), Coupling%visbmdi_with_scaled_co2(n,:),  &
-             Coupling%visdfdi_with_scaled_co2(n,:), ix, im, levs, Model%daily_mean,         &
+             Coupling%sfcdlw_with_scaled_co2(n,:), Diag%topfsw_with_scaled_co2(n,:),        &
+             Radtend%htrsw_with_scaled_co2(n,:,:), Radtend%swhc_with_scaled_co2(n,:,:),     &
+             Radtend%htrlw_with_scaled_co2(n,:,:), Radtend%lwhc_with_scaled_co2(n,:,:),     &
+             Coupling%nirbmui_with_scaled_co2(n,:), Coupling%nirdfui_with_scaled_co2(n,:),  &
+             Coupling%visbmui_with_scaled_co2(n,:), Coupling%visdfui_with_scaled_co2(n,:),  &
+             Coupling%nirbmdi_with_scaled_co2(n,:), Coupling%nirdfdi_with_scaled_co2(n,:),  &
+             Coupling%visbmdi_with_scaled_co2(n,:), Coupling%visdfdi_with_scaled_co2(n,:),  &
+             ix, im, levs, Model%daily_mean,                                                &
     !  ---  input/output:
              dtdt, dtdtc,                                                                   &
     !  ---  outputs:
              adjsfcdsw, adjsfcnsw, adjsfcdlw, adjsfculw, xmu, xcosz, adjnirbmu, adjnirdfu,  &
              adjvisbmu, adjvisdfu, adjnirbmd, adjnirdfd, adjvisbmd,                         &
-             adjvisdfd                                                                      &
+             adjvisdfd, adjtoadsw, adjtoausw                                                &
            )
 
         Diag%dlwsfc_with_scaled_co2(n,:) = Diag%dlwsfc_with_scaled_co2(n,:) + adjsfcdlw * Model%dtf
         Diag%ulwsfc_with_scaled_co2(n,:) = Diag%ulwsfc_with_scaled_co2(n,:) + adjsfculw * Model%dtf
+
+        Diag%dswtoa_with_scaled_co2(n,:) = Diag%dswtoa_with_scaled_co2(n,:) + adjtoadsw * Model%dtf
+        Diag%uswtoa_with_scaled_co2(n,:) = Diag%uswtoa_with_scaled_co2(n,:) + adjtoausw * Model%dtf
+        Diag%dswtoai_with_scaled_co2(n,:) = adjtoadsw
+        Diag%uswtoai_with_scaled_co2(n,:) = adjtoausw
 
         Diag%dlwsfci_with_scaled_co2(n,:) = adjsfcdlw
         Diag%ulwsfci_with_scaled_co2(n,:) = adjsfculw

--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -1273,6 +1273,10 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: ulwsfc_with_scaled_co2(:,:) => null()    !< interval-average lw up at sfc with scaled carbon dioxide (w/m**2)
     real (kind=kind_phys), pointer :: dswsfc_with_scaled_co2(:,:) => null()    !< interval-average sw dn at sfc with scaled carbon dioxide (w/m**2)
     real (kind=kind_phys), pointer :: uswsfc_with_scaled_co2(:,:) => null()    !< interval-average sw up at sfc with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: dswtoa_with_scaled_co2(:,:) => null()    !< interval-average sw dn at toa with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: uswtoa_with_scaled_co2(:,:) => null()    !< interval-average sw up at toa with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: dswtoai_with_scaled_co2(:,:) => null()    !< instantaneous sw dn at toa with scaled carbon dioxide (w/m**2)
+    real (kind=kind_phys), pointer :: uswtoai_with_scaled_co2(:,:) => null()    !< instantaneous sw up at toa with scaled carbon dioxide (w/m**2)
 
     real (kind=kind_phys), pointer :: htrlw_with_scaled_co2(:,:,:) => null()    !< instantaneous 3d all-sky longwave radiative heating rate with scaled co2
     real (kind=kind_phys), pointer :: htrsw_with_scaled_co2(:,:,:) => null()    !< instantaneous 3d all-sky shortwave radiative heating rate with scaled co2
@@ -1306,6 +1310,10 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: dlwsfc_override (:) => null()   !< time accumulated sfc dn lw flux ( w/m**2 ) when gfs_physics_nml.override_surface_radiative_fluxes == .true.
     real (kind=kind_phys), pointer :: dswsfc_override (:) => null()   !< time accumulated sfc dn sw flux ( w/m**2 ) when gfs_physics_nml.override_surface_radiative_fluxes == .true.
     real (kind=kind_phys), pointer :: uswsfc_override (:) => null()   !< time accumulated sfc up sw flux ( w/m**2 ) when gfs_physics_nml.override_surface_radiative_fluxes == .true.
+    real (kind=kind_phys), pointer :: dswtoa (:)    => null()   !< time accumulated toa dn sw flux ( w/m**2 )
+    real (kind=kind_phys), pointer :: uswtoa (:)    => null()   !< time accumulated toa up sw flux ( w/m**2 )
+    real (kind=kind_phys), pointer :: dswtoai (:)    => null()   !< instantaneous toa dn sw flux ( w/m**2 )
+    real (kind=kind_phys), pointer :: uswtoai (:)    => null()   !< instantaneous toa up sw flux ( w/m**2 )
     real (kind=kind_phys), pointer :: suntim (:)    => null()   !< sunshine duration time (s)
     real (kind=kind_phys), pointer :: runoff (:)    => null()   !< total water runoff
     real (kind=kind_phys), pointer :: ep     (:)    => null()   !< potential evaporation
@@ -4063,6 +4071,10 @@ end subroutine overrides_create
        allocate (Diag%ulwsfc_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM))
        allocate (Diag%dswsfc_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM))
        allocate (Diag%uswsfc_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Diag%dswtoa_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Diag%uswtoa_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Diag%dswtoai_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM))
+       allocate (Diag%uswtoai_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM))
        if (Model%ldiag3d) then
           allocate (Diag%htrlw_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM,Model%levs))
           allocate (Diag%htrsw_with_scaled_co2 (Model%n_diagnostic_radiation_calls,IM,Model%levs))
@@ -4099,6 +4111,10 @@ end subroutine overrides_create
     endif
     allocate (Diag%ulwsfc  (IM))
     allocate (Diag%uswsfc  (IM))
+    allocate (Diag%dswtoa  (IM))
+    allocate (Diag%uswtoa  (IM))
+    allocate (Diag%dswtoai  (IM))
+    allocate (Diag%uswtoai  (IM))
     if (Model%override_surface_radiative_fluxes) then
       allocate (Diag%dlwsfc_override(IM))
       allocate (Diag%dswsfc_override(IM))
@@ -4374,6 +4390,10 @@ end subroutine overrides_create
        Diag%ulwsfc_with_scaled_co2 = zero
        Diag%dswsfc_with_scaled_co2 = zero
        Diag%uswsfc_with_scaled_co2 = zero
+       Diag%dswtoa_with_scaled_co2 = zero
+       Diag%uswtoa_with_scaled_co2 = zero
+       Diag%dswtoai_with_scaled_co2 = zero
+       Diag%uswtoai_with_scaled_co2 = zero
        ! Note the 3d radiation multi-call diagnostics are handled as
        ! diagnostics manager controlled fields, so they do not need
        ! to be manually zeroed, so we do not touch them here.
@@ -4415,6 +4435,10 @@ end subroutine overrides_create
     Diag%tclim_iano    = zero
     Diag%ulwsfc  = zero
     Diag%uswsfc  = zero
+    Diag%dswtoa  = zero
+    Diag%uswtoa  = zero
+    Diag%dswtoai = zero
+    Diag%uswtoai = zero
     Diag%suntim  = zero
     Diag%runoff  = zero
     Diag%ep      = zero


### PR DESCRIPTION
**Description**

While SHiELD provides zenith-angle-adjusted surface shortwave radiative flux diagnostics, corresponding zenith-angle-adjusted top of atmosphere diagnostics are not made available. This PR adds a full suite of zenith-angle-adjusted top-of-atmosphere shortwave radiative flux diagnostics: upward and downward; interval-averaged and instantaneous; standard and radiation multi-call. 

I might argue these should be the default top of atmosphere shortwave radiative flux diagnostics, so I am open to suggestions for naming to make this more apparent. The reason for this is that SHiELD performs this zenith-angle-adjustment not only to the shortwave radiative fluxes it passes to the land surface:

https://github.com/NOAA-GFDL/SHiELD_physics/blob/d323480c8107be9d7daa15f8782c1bdd75dfb768/gsmphys/dcyc2.f#L222-L223

but also the shortwave temperature tendency it applies throughout the atmospheric column:

https://github.com/NOAA-GFDL/SHiELD_physics/blob/d323480c8107be9d7daa15f8782c1bdd75dfb768/gsmphys/dcyc2.f#L241

For physical consistency, this implies an identical adjustment to the TOA fluxes. 

We can see this when we try to diagnose the column shortwave energy budget:

```math
SW^{down}_{toa} + SW^{up}_{sfc} - SW^{up}_{toa} - SW^{down}_{sfc} = \frac{1}{g}\int_0^{p_s} c_{vm} \left( \frac{\partial T}{\partial t} \right)_{SW} dp.
```

With existing diagnostics it is not possible to accurately diagnose this relationship. The right-hand-side is fully zenith-angle-adjusted—and ultimately what the atmosphere feels—but we can only output zenith-angle-adjusted boundary fluxes at the surface.  The plot below illustrates this situation for an arbitrary 6-hour interval average: the left panel illustrates the residual if we use all unadjusted fluxes for the left-hand-side; the middle panel illustrates if we use unadjusted fluxes for the TOA and adjusted fluxes for the surface; and finally the right panel illustrates if we use the newly added adjusted TOA fluxes and existing adjusted fluxes at the surface.

![2025-05-02-shortwave-residual-interval-average](https://github.com/user-attachments/assets/8fce78a3-4151-46dc-b6a6-aa7eb396e477)

The panel titles provide the internal names of the flux diagnostics used—using fully zenith-angle-adjusted fluxes provides a near-perfect match.

We can do this with instantaneous diagnostics as well—in this case unadjusted instantaneous surface flux diagnostics do not exist, so we only have the middle and right panels. Again there is a near-perfect match in the right panel.

![2025-05-02-shortwave-residual-instantaneous](https://github.com/user-attachments/assets/51d8a827-6430-4b87-8c88-c24934deac98)

For the right-hand-side in each of these comparisons I am using the existing `vertically_integrated_tendency_of_air_temperature_due_to_shortwave_heating` diagnostic, which I added previously.

cc: @lharris4 @linjiongzhou — I realize this is a bit in the weeds, but I am curious if you follow / agree with my reasoning.

**How Has This Been Tested?**

See the discussion above for testing these diagnostics for physical consistency. I have tested the radiation multi-call components of these diagnostics by checking that they produce identical results with their non-multi-call counterparts when the carbon dioxide scale factor is set to `1.0`.  See [this notebook](https://gist.github.com/spencerkclark/8e13ab56fe335e434883251d7884555e) for the code for making these plots and asserting the accuracy of the radiation multi-call fields.

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
