### PR TITLE
quick fix to longitude conversion in co2 assignment

### DIFF
--- a/gsmphys/radiation_gases.f
+++ b/gsmphys/radiation_gases.f
@@ -1022,9 +1022,9 @@
         tmp = raddeg / resco2
         do i = 1, IMAX
           xlon1 = xlon(i)
-          if ( xlon1 < 0.0 ) xlon1 = xlon1 + con_pi  ! if xlon in -pi->pi, convert to 0->2pi
-          xlat1 = hfpi - xlat(i)                     ! if xlat in pi/2 -> -pi/2 range
-!note     xlat1 = xlat(i)                            ! if xlat in 0 -> pi range
+          if ( xlon1 < 0.0 ) xlon1 = xlon1 + 2*con_pi  ! if xlon in -pi->pi, convert to 0->2pi
+          xlat1 = hfpi - xlat(i)                       ! if xlat in pi/2 -> -pi/2 range
+!note     xlat1 = xlat(i)                              ! if xlat in 0 -> pi range
 
           ilon = min( IMXCO2, int( xlon1*tmp + 1 ))
           ilat = min( JMXCO2, int( xlat1*tmp + 1 ))


### PR DESCRIPTION
**Description**

Changes the conversion of longitudes from `-pi -- pi` to `0 -- 2pi` so negative values are mapped to values greater than pi.

Fixes # 66

**Checklist:**

Please check all whether they apply or not
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
