### PR TITLE
Fix tracer blowups due to incorrect tracer ordering in the implicit coupling refactor

### DIFF
--- a/GFS_layer/GFS_physics_driver.F90
+++ b/GFS_layer/GFS_physics_driver.F90
@@ -1569,7 +1569,7 @@ module module_physics_driver
                        Model%l2_diag_opt, Model%use_lup_only, Model%l1l2_blend_opt, &
                        Model%use_l1_sfc, Model%use_tke_pbl, Model%use_shear_pbl,    &
                        dkt, Statemid%stored_flux_cg, Statemid%stored_flux_en, Statemid%stored_elm_pbl, & !cg as up and en as down
-                       Statemid%stored_au_out,Statemid%stored_f1_out,Statemid%stored_f2_out, Statemid%stored_diss_out) ! output of the tridiagonal matrix for heat, moisture, tracers !joseph
+                       Statemid%stored_au_out,Statemid%stored_f1_out,Statemid%stored_f2_out, Statemid%stored_q1_out, Statemid%stored_diss_out) ! output of the tridiagonal matrix for heat, moisture, tracers !joseph
 
           endif
         endif
@@ -1999,7 +1999,7 @@ module module_physics_driver
 !!!                       au_out,f1_out,f2_out, diss_out)
 
                 call satmedmfvdifq_up(ix, im, levs, nvdiff, model%ntke,                  &
-                       Statemid%stored_dtdt, Statemid%stored_dqdt, Statein%qgrs, Statein%tgrs, model%dspheat, model%dspfac,                &
+                       Statemid%stored_dtdt, Statemid%stored_dqdt, Statemid%stored_q1_out, Statein%tgrs, model%dspheat, model%dspfac,                &
                        Statemid%stored_del, dtp,                                                           &
                        Statemid%stored_dtsfc1, Statemid%stored_dqsfc1,                                                     &
                        Statemid%stored_au_out, Statemid%stored_f1_out, Statemid%stored_f2_out, Statemid%stored_diss_out)

--- a/GFS_layer/GFS_typedefs.F90
+++ b/GFS_layer/GFS_typedefs.F90
@@ -1032,6 +1032,7 @@ module GFS_typedefs
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     real(kind=kind_phys), allocatable :: stored_au_out(:,:), stored_f1_out(:,:), stored_f2_out(:,:), stored_diss_out(:,:)
+    real(kind=kind_phys), allocatable :: stored_q1_out(:,:,:)
     integer, allocatable :: stored_kpbl(:)
     real(kind=kind_phys), allocatable :: stored_flux_cg(:,:), stored_flux_en(:,:), stored_elm_pbl(:,:)
     real(kind=kind_phys), allocatable :: stored_dudt(:,:), stored_dvdt(:,:), stored_dqdt(:,:,:)
@@ -4026,6 +4027,7 @@ end subroutine overrides_create
      allocate (Statemid%stored_au_out(IM,model%levs-1))
      allocate (Statemid%stored_f1_out(IM,model%levs))
      allocate (Statemid%stored_f2_out(IM,model%levs*(model%ntrac-1)))
+     allocate (Statemid%stored_q1_out(IM,model%levs,model%ntrac))
      allocate (Statemid%stored_diss_out(IM,model%levs-1))
 
      allocate (Statemid%stored_kpbl(IM))

--- a/gsmphys/satmedmfvdifq_down_up.f
+++ b/gsmphys/satmedmfvdifq_down_up.f
@@ -64,7 +64,7 @@
      &     use_tke_ent_det,use_shear,
      &     dkt_out, flux_up, flux_dn, elm,
 !    to be passed for the upward sweep
-     &     au_out, f1_out, f2_out, diss_out) 
+     &     au_out, f1_out, f2_out, q1_out, diss_out)
 
       use machine  , only : kind_phys
       use funcphys , only : fpvs
@@ -79,7 +79,7 @@
 !----------------------------------------------------------------------
       real(kind=kind_phys) au_out(im,km-1)
       real(kind=kind_phys) f1_out(im,km), f2_out(im,km*(ntrac-1)),
-     &                     diss_out(im,km-1) 
+     &                     diss_out(im,km-1), q1_out(im,km,ntrac)
 !----------------------------------------------------------------------
 !----------------------------------------------------------------------
       integer ix, im, km, ntrac, ntcw, ntiw, ntke, ntcw_new
@@ -1622,6 +1622,7 @@ c     Save upper diag and RHS for upward sweep
 
       ! to be rearranged in the upward sweep
       rtg_in(:,:,:)=rtg(:,:,:)
+      q1_out(:,:,:)=q1(:,:,:)
 
 
 ! Commented out, to be done in the upward sweep


### PR DESCRIPTION
Recent development work uncovered a blowup case where ozone values became unrealistic after few hours of simulation. Upon investigation, the field table used in that run had `sgs_tke` not in the last position, which triggered the tracer rearrangement algorithm.
The `q1` field in the `_up` sweep was still use the none rearranged tracer order leading to incorrect tendencies for the flipped tracers. This PR will fix this issue while preserving the original logic. 
